### PR TITLE
Build functional Inbox web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,74 @@
-# Inbox
+# InBox – prototype fonctionnel
 
-Welcome to the new Inbox web app.
-InBox create a single place to store all your document. It as simple as send everything from message text and email. No app to install! Just add the Inbox email adress and phone number to your contact and, that's it!! Send everything that is important for future retrieve and review. Access all your document trew the web app interface, that will let you tag everything easily to organize your documents. Or give access to your assistant! So he can review everyth
+Prototype complet qui couvre les parcours clés décrits dans le cahier des charges InBox : réception de factures (SMS, courriel, upload), tagging par glisser-déposer, corrections des champs OCR, conversation rattachée à chaque facture et création d'éléments depuis l'application. Contrairement à la version statique précédente, cette déclinaison embarque un serveur Node.js léger, un stockage persistant (fichier JSON) et une API REST consommée par l'interface.
 
-## Features
-- Organize tasks and messages
-- Prioritize important items
-- User-friendly interface
+## Pile technique
 
-Feel free to explore the code, contribute, and make this project even better!
-## Features
-- Organize tasks and messages
-- Prioritize important items
-- User-friendly interface
+- **Serveur Node.js natif** – HTTP + routage maison (aucune dépendance externe) qui expose les ressources `tags`, `invoices` et `messages`.
+- **Base de données fichier** – `data/db.json` contient l'organisation de démonstration, les utilisateurs, factures, tags et historiques de chat. Toute modification depuis l'UI est automatiquement persistée.
+- **Frontend vanilla** – HTML/CSS/JS servis depuis `public/`, avec drag & drop natif, gestion des toasts, formulaires et polling léger pour le chat.
 
-Feel free to explore the code, contribute, and make this project even better!
+## Démarrage rapide
+
+```bash
+cd inbox
+node server.js
+# Ouvrir http://localhost:4173 dans le navigateur
+```
+
+> Aucun `npm install` n'est requis : le serveur n'utilise que les modules standards de Node.
+
+### Données de départ
+
+Le fichier `data/db.json` contient une organisation fictive (Coop Atlas), 4 utilisateurs, 4 tags globaux, 3 factures d'exemple et un historique de chat. Vous pouvez modifier ce fichier pour ajuster les scénarios ou repartir d'un état initial.
+
+## Parcours couverts côté UI
+
+1. **Filtrer/Rechercher** – Recherche plein texte et filtres (statut, tag, période) déclenchent un appel `GET /api/invoices`.
+2. **Sélectionner une facture** – Charge les détails (`GET /api/invoices/{id}`) + fil de messages, met à jour la barre de résumé et les boutons d'action.
+3. **Tagging drag & drop** – Glisser un tag vers l'aperçu (`POST /api/invoices/{id}/tags`) ou vers la zone “Supprimer” (`DELETE /api/invoices/{id}/tags/{tagId}`) avec toast Undo.
+4. **Création de tag inline** – Bouton `＋` → input inline → `POST /api/tags`, prévention des doublons et remise à jour du panneau/filtre.
+5. **Correction OCR** – Edition inline des pills, envoi `PATCH /api/invoices/{id}` (champ `ocrFields`) et feedback de confirmation.
+6. **Chat attaché** – Formulaire `POST /api/invoices/{id}/messages`, rafraîchissement toutes les 5 s, alignement entrant/sortant et auto-scroll.
+7. **Changement de statut** – Boutons “Marquer à vérifier / Marquer comme complétée” qui persistent via `PATCH /api/invoices/{id}` et mettent à jour la liste.
+8. **Intake manuel** – Dialogue “Ajouter une facture” accessible via le bouton Upload, `POST /api/invoices`, puis sélection automatique dans la liste.
+
+## API REST disponible
+
+| Méthode | Route | Description |
+| --- | --- | --- |
+| GET | `/api/invoices` | Liste des factures (filtres `search`, `status`, `tag`, `period`) |
+| POST | `/api/invoices` | Créer une facture manuelle |
+| GET | `/api/invoices/{id}` | Détails d'une facture, tags enrichis, métadonnées expéditeur |
+| PATCH | `/api/invoices/{id}` | Mettre à jour statut/valeurs OCR/méta |
+| POST | `/api/invoices/{id}/tags` | Appliquer un tag |
+| DELETE | `/api/invoices/{id}/tags/{tagId}` | Retirer un tag |
+| GET | `/api/invoices/{id}/messages` | Historique du chat |
+| POST | `/api/invoices/{id}/messages` | Ajouter un message (in-app ou SMS) |
+| GET | `/api/tags` | Liste des tags avec compteur d'usage |
+| POST | `/api/tags` | Créer un tag |
+| DELETE | `/api/tags/{id}` | Supprimer un tag non utilisé |
+
+Chaque réponse JSON contient les libellés enrichis (`statusLabel`, `authorName`, `appliedByName`, etc.) pour faciliter le rendu frontend.
+
+## Structure du dépôt
+
+```
+public/
+  index.html      # Layout + templates + dialogue de création
+  src/app.js      # Logique front (fetch API, DnD, chat, formulaires, toasts)
+  src/styles.css  # Thème sombre, layout 3 colonnes, modale intake
+server.js         # Serveur HTTP + routes REST + static serving
+data/db.json      # Jeu de données persistant
+```
+
+## Tests manuels conseillés
+
+- `GET /api/invoices` + filtre `status=a_verifier` pour valider les requêtes.
+- Ajouter un tag via l'UI, observer le compteur d'usage évoluer dans le panneau.
+- Créer une facture depuis la modale puis vérifier la persistance dans `data/db.json`.
+- Envoyer un message dans le chat et constater sa présence après rafraîchissement.
+
+## Licence
+
+MIT

--- a/data/db.json
+++ b/data/db.json
@@ -1,0 +1,325 @@
+{
+  "orgs": [
+    {
+      "id": "org-demo",
+      "name": "Coop Atlas"
+    }
+  ],
+  "users": [
+    {
+      "id": "user-admin",
+      "orgId": "org-demo",
+      "name": "Amélie Dufresne",
+      "email": "amelie@coopatlas.ca",
+      "phone": "+15145550111",
+      "role": "admin",
+      "status": "active",
+      "notificationPreferences": {
+        "sms": true,
+        "email": true
+      }
+    },
+    {
+      "id": "user-tagger",
+      "orgId": "org-demo",
+      "name": "Léa Gervais",
+      "email": "lea@coopatlas.ca",
+      "phone": "+15145550145",
+      "role": "tagger",
+      "status": "active",
+      "notificationPreferences": {
+        "sms": true,
+        "email": true
+      }
+    },
+    {
+      "id": "user-submit-1",
+      "orgId": "org-demo",
+      "name": "Julien Morin",
+      "email": "julien@coopatlas.ca",
+      "phone": "+15145550187",
+      "role": "submitter",
+      "status": "active",
+      "notificationPreferences": {
+        "sms": true,
+        "email": false
+      }
+    },
+    {
+      "id": "user-submit-2",
+      "orgId": "org-demo",
+      "name": "Sara Blanchette",
+      "email": "sara@coopatlas.ca",
+      "phone": "+15145550162",
+      "role": "submitter",
+      "status": "active",
+      "notificationPreferences": {
+        "sms": false,
+        "email": true
+      }
+    }
+  ],
+  "tags": [
+    {
+      "id": "tag-fuel",
+      "orgId": "org-demo",
+      "label": "Essence",
+      "color": "#f97316",
+      "isSystem": false,
+      "createdAt": "2024-02-01T13:05:00.000Z",
+      "createdByUserId": "user-admin"
+    },
+    {
+      "id": "tag-meal",
+      "orgId": "org-demo",
+      "label": "Repas",
+      "color": "#ec4899",
+      "isSystem": false,
+      "createdAt": "2024-02-14T09:12:00.000Z",
+      "createdByUserId": "user-admin"
+    },
+    {
+      "id": "tag-card",
+      "orgId": "org-demo",
+      "label": "Carte de crédit",
+      "color": "#22d3ee",
+      "isSystem": true,
+      "createdAt": "2024-02-19T08:30:00.000Z",
+      "createdByUserId": "user-admin"
+    },
+    {
+      "id": "tag-to-review",
+      "orgId": "org-demo",
+      "label": "À approuver",
+      "color": "#a855f7",
+      "isSystem": false,
+      "createdAt": "2024-03-04T11:45:00.000Z",
+      "createdByUserId": "user-tagger"
+    }
+  ],
+  "invoices": [
+    {
+      "id": "inv-gas-001",
+      "orgId": "org-demo",
+      "senderUserId": "user-submit-1",
+      "senderPhone": "+15145550187",
+      "source": "sms",
+      "originalFilename": "IMG_3421.jpg",
+      "driveFileId": "drive-1001",
+      "driveFileUrl": "https://drive.google.com/file/d/drive-1001",
+      "previewUrl": "https://images.unsplash.com/photo-1529429617124-aee1114814c4?auto=format&fit=crop&w=800&q=80",
+      "vendor": "Shell Canada",
+      "invoiceDate": "2024-03-04",
+      "amountTotal": 82.31,
+      "tps": 3.44,
+      "tvq": 6.87,
+      "paymentMethod": "Visa •••• 1234",
+      "status": "a_verifier",
+      "notes": "Plein d'essence camion livraison",
+      "tags": [
+        {
+          "tagId": "tag-fuel",
+          "appliedByUserId": "user-tagger",
+          "createdAt": "2024-03-05T14:30:00.000Z"
+        },
+        {
+          "tagId": "tag-card",
+          "appliedByUserId": "user-tagger",
+          "createdAt": "2024-03-05T14:30:10.000Z"
+        }
+      ],
+      "ocrFields": [
+        {
+          "id": "vendor",
+          "label": "Fournisseur",
+          "value": "Shell Canada",
+          "confidence": 0.78,
+          "confirmed": true
+        },
+        {
+          "id": "invoiceDate",
+          "label": "Date",
+          "value": "2024-03-04",
+          "confidence": 0.82,
+          "confirmed": false
+        },
+        {
+          "id": "amountTotal",
+          "label": "Montant",
+          "value": "82.31",
+          "confidence": 0.93,
+          "confirmed": true
+        },
+        {
+          "id": "tps",
+          "label": "TPS",
+          "value": "3.44",
+          "confidence": 0.74,
+          "confirmed": false
+        },
+        {
+          "id": "tvq",
+          "label": "TVQ",
+          "value": "6.87",
+          "confidence": 0.69,
+          "confirmed": false
+        },
+        {
+          "id": "paymentMethod",
+          "label": "Paiement",
+          "value": "Visa •••• 1234",
+          "confidence": 0.55,
+          "confirmed": false
+        }
+      ],
+      "createdAt": "2024-03-04T22:20:00.000Z",
+      "updatedAt": "2024-03-05T14:30:10.000Z"
+    },
+    {
+      "id": "inv-meal-002",
+      "orgId": "org-demo",
+      "senderUserId": "user-submit-2",
+      "senderEmail": "sara@coopatlas.ca",
+      "source": "email",
+      "originalFilename": "BonRestaurant.pdf",
+      "driveFileId": "drive-1002",
+      "driveFileUrl": "https://drive.google.com/file/d/drive-1002",
+      "previewUrl": "https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=800&q=80",
+      "vendor": "Bistro Limoilou",
+      "invoiceDate": "2024-03-02",
+      "amountTotal": 128.5,
+      "tps": 5.12,
+      "tvq": 10.27,
+      "paymentMethod": "Mastercard •••• 8876",
+      "status": "complete",
+      "notes": "Repas client - Projet Atlas",
+      "tags": [
+        {
+          "tagId": "tag-meal",
+          "appliedByUserId": "user-tagger",
+          "createdAt": "2024-03-03T11:05:00.000Z"
+        },
+        {
+          "tagId": "tag-card",
+          "appliedByUserId": "user-tagger",
+          "createdAt": "2024-03-03T11:05:04.000Z"
+        }
+      ],
+      "ocrFields": [
+        {
+          "id": "vendor",
+          "label": "Fournisseur",
+          "value": "Bistro Limoilou",
+          "confidence": 0.91,
+          "confirmed": true
+        },
+        {
+          "id": "invoiceDate",
+          "label": "Date",
+          "value": "2024-03-02",
+          "confidence": 0.86,
+          "confirmed": true
+        },
+        {
+          "id": "amountTotal",
+          "label": "Montant",
+          "value": "128.50",
+          "confidence": 0.94,
+          "confirmed": true
+        },
+        {
+          "id": "paymentMethod",
+          "label": "Paiement",
+          "value": "Mastercard •••• 8876",
+          "confidence": 0.68,
+          "confirmed": false
+        }
+      ],
+      "createdAt": "2024-03-02T20:12:00.000Z",
+      "updatedAt": "2024-03-03T11:05:04.000Z"
+    },
+    {
+      "id": "inv-saas-003",
+      "orgId": "org-demo",
+      "senderUserId": "user-submit-1",
+      "senderEmail": "julien@coopatlas.ca",
+      "source": "upload",
+      "originalFilename": "Invoice_March.pdf",
+      "driveFileId": "drive-1003",
+      "driveFileUrl": "https://drive.google.com/file/d/drive-1003",
+      "previewUrl": "https://images.unsplash.com/photo-1587613865525-5d0aeaa8c1ae?auto=format&fit=crop&w=800&q=80",
+      "vendor": "Figma",
+      "invoiceDate": "2024-03-01",
+      "amountTotal": 45,
+      "tps": 0,
+      "tvq": 0,
+      "paymentMethod": "Carte Visa •••• 1234",
+      "status": "nouvelle",
+      "notes": "Abonnement mensuel équipe design",
+      "tags": [
+        {
+          "tagId": "tag-card",
+          "appliedByUserId": "user-admin",
+          "createdAt": "2024-03-01T09:00:00.000Z"
+        }
+      ],
+      "ocrFields": [
+        {
+          "id": "vendor",
+          "label": "Fournisseur",
+          "value": "Figma",
+          "confidence": 0.95,
+          "confirmed": true
+        },
+        {
+          "id": "invoiceDate",
+          "label": "Date",
+          "value": "2024-03-01",
+          "confidence": 0.89,
+          "confirmed": true
+        },
+        {
+          "id": "amountTotal",
+          "label": "Montant",
+          "value": "45.00",
+          "confidence": 0.97,
+          "confirmed": true
+        }
+      ],
+      "createdAt": "2024-03-01T09:00:00.000Z",
+      "updatedAt": "2025-09-16T03:49:27.968Z"
+    }
+  ],
+  "messages": [
+    {
+      "id": "msg-1",
+      "invoiceId": "inv-gas-001",
+      "fromUserId": "user-tagger",
+      "body": "Salut Julien! Peux-tu confirmer que c'est bien pour le camion de Québec?",
+      "attachments": [],
+      "sentVia": "inapp",
+      "deliveryStatus": "delivered",
+      "createdAt": "2024-03-05T14:32:00.000Z"
+    },
+    {
+      "id": "msg-2",
+      "invoiceId": "inv-gas-001",
+      "fromExternalPhone": "+15145550187",
+      "body": "Oui c'est pour la tournée de Québec, merci!",
+      "attachments": [],
+      "sentVia": "sms",
+      "deliveryStatus": "delivered",
+      "createdAt": "2024-03-05T14:35:00.000Z"
+    },
+    {
+      "id": "msg-3",
+      "invoiceId": "inv-meal-002",
+      "fromUserId": "user-tagger",
+      "body": "Pense à ajouter le détail du client sur la note de frais svp",
+      "attachments": [],
+      "sentVia": "inapp",
+      "deliveryStatus": "delivered",
+      "createdAt": "2024-03-03T11:05:30.000Z"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "inbox",
+  "version": "1.0.0",
+  "description": "Inbox – centralisation des factures (prototype fonctionnel)",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [
+    "inbox",
+    "factures",
+    "ocr",
+    "tags"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>InBox – Centralisation des factures</title>
+    <link rel="stylesheet" href="src/styles.css" />
+  </head>
+  <body>
+    <div class="app" data-view="list">
+      <aside class="primary-rail" aria-label="Navigation principale">
+        <div class="primary-rail__brand" aria-label="InBox">
+          <span class="brand-mark">INBoX</span>
+        </div>
+        <nav class="primary-rail__nav" aria-label="Collections">
+          <button class="rail-button is-active" type="button" data-section="collections" aria-pressed="true">
+            <span aria-hidden="true">📄</span>
+            <span class="rail-label">Collections</span>
+          </button>
+          <button class="rail-button" type="button" data-section="tags">
+            <span aria-hidden="true">🏷️</span>
+            <span class="rail-label">Tags</span>
+          </button>
+          <button class="rail-button" type="button" data-section="recent">
+            <span aria-hidden="true">🕒</span>
+            <span class="rail-label">Recent</span>
+          </button>
+          <button class="rail-button" type="button" data-section="starred">
+            <span aria-hidden="true">⭐</span>
+            <span class="rail-label">Starred</span>
+          </button>
+          <button class="rail-button" type="button" data-section="trash">
+            <span aria-hidden="true">🗑️</span>
+            <span class="rail-label">Trash</span>
+          </button>
+        </nav>
+        <div class="primary-rail__actions">
+          <button class="upload-button" type="button" id="newUploadButton">
+            <span aria-hidden="true">⬆️</span>
+            <span class="rail-label">Upload</span>
+          </button>
+        </div>
+      </aside>
+
+      <main class="workspace" aria-label="Espace de travail">
+        <header class="workspace__header">
+          <div class="search-group">
+            <label class="field" for="searchInput">
+              <span class="field__icon" aria-hidden="true">🔍</span>
+              <input
+                id="searchInput"
+                type="search"
+                placeholder="Rechercher fournisseur, montant, date ou tag"
+                autocomplete="off"
+              />
+            </label>
+            <button class="ghost-button" type="button" id="clearSearchButton" aria-label="Effacer la recherche">✕</button>
+          </div>
+          <div class="filter-group" role="group" aria-label="Filtres">
+            <label class="filter">
+              <span>Statut</span>
+              <select id="statusFilter">
+                <option value="all">Tous</option>
+                <option value="nouvelle">Nouvelles</option>
+                <option value="a_verifier">À vérifier</option>
+                <option value="complete">Complètes</option>
+                <option value="archive">Archivées</option>
+                <option value="ocr_error">Erreur OCR</option>
+              </select>
+            </label>
+            <label class="filter">
+              <span>Tag</span>
+              <select id="tagFilter">
+                <option value="all">Tous les tags</option>
+              </select>
+            </label>
+            <label class="filter">
+              <span>Période</span>
+              <select id="periodFilter">
+                <option value="all">Toute période</option>
+                <option value="today">Aujourd'hui</option>
+                <option value="7d">7 derniers jours</option>
+                <option value="30d">30 derniers jours</option>
+              </select>
+            </label>
+          </div>
+        </header>
+
+        <div class="workspace__body">
+          <section class="inbox" aria-label="Liste des factures">
+            <header class="inbox__header">
+              <h1>Inbox</h1>
+              <p class="inbox__hint">Glissez une facture vers un tag pour l'appliquer en lot.</p>
+            </header>
+            <ul class="inbox__list" id="invoiceList" role="list"></ul>
+            <p class="empty-state" id="emptyState" hidden>Aucun résultat. Essayez d'ajuster vos filtres.</p>
+          </section>
+
+          <section class="invoice" aria-live="polite">
+            <header class="invoice__header">
+              <div class="invoice__meta">
+                <p class="invoice__vendor" id="invoiceVendor">Sélectionnez une facture</p>
+                <p class="invoice__summary" id="invoiceSummary">Choisissez un élément dans la liste pour afficher les détails.</p>
+              </div>
+              <div class="invoice__status" id="statusChip"></div>
+            </header>
+            <div class="invoice__columns">
+              <aside class="tag-panel" aria-label="Panneau de tags">
+                <div class="tag-panel__actions">
+                  <button class="tag-button tag-button--add" type="button" id="addTagButton" aria-label="Créer un nouveau tag">＋</button>
+                  <div class="tag-button tag-button--remove" id="removeTagDropzone" role="button" aria-label="Zone de suppression">
+                    <span aria-hidden="true">−</span>
+                    <span class="tag-button__label">Supprimer</span>
+                  </div>
+                </div>
+                <ul class="tag-panel__list" id="tagList" role="listbox" aria-label="Tags disponibles"></ul>
+              </aside>
+
+              <div class="preview" aria-label="Prévisualisation de la facture">
+                <div class="preview__stage" id="previewStage" role="button" tabindex="0" aria-label="Déposer un tag ici pour l'appliquer">
+                  <div class="preview__media" id="previewMedia" role="img" aria-live="polite"></div>
+                  <div class="applied-tags" id="appliedTags" aria-label="Tags appliqués"></div>
+                  <p class="preview__hint" id="previewHint">Déposez un tag pour l'appliquer.</p>
+                </div>
+                <div class="review-bar">
+                  <div class="review-bar__info">
+                    <p id="invoiceChannel" class="review-bar__channel"></p>
+                    <p id="invoiceTimestamp" class="review-bar__time"></p>
+                  </div>
+                  <div class="review-bar__actions">
+                    <button class="pill-button" type="button" id="sendToReviewButton">Marquer à vérifier</button>
+                    <button class="pill-button pill-button--primary" type="button" id="markCompleteButton">Marquer comme complétée</button>
+                  </div>
+                </div>
+                <section class="chat" aria-label="Fil de discussion">
+                  <header class="chat__header">
+                    <h2>Chat</h2>
+                    <p id="chatPartner" class="chat__partner"></p>
+                  </header>
+                  <ul class="chat__messages" id="chatMessages" role="list"></ul>
+                  <form class="chat__composer" id="chatForm" novalidate>
+                    <label class="field chat__input">
+                      <input
+                        type="text"
+                        id="chatInput"
+                        name="message"
+                        autocomplete="off"
+                        placeholder="Répondre…"
+                        aria-label="Écrire un message"
+                      />
+                    </label>
+                    <button class="pill-button pill-button--primary" type="submit">Envoyer</button>
+                  </form>
+                </section>
+              </div>
+
+              <aside class="ocr-panel" aria-label="Champs OCR">
+                <header class="ocr-panel__header">
+                  <h2>Champs extraits</h2>
+                  <p class="ocr-panel__hint">Corrigez les valeurs et marquez-les comme confirmées.</p>
+                </header>
+                <ul class="ocr-panel__list" id="ocrFieldList"></ul>
+              </aside>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+
+    <div class="toast-container" id="toastContainer" role="status" aria-live="assertive"></div>
+
+    <template id="invoiceRowTemplate">
+      <li class="inbox-item">
+        <button class="inbox-item__button" type="button">
+          <div class="inbox-item__top">
+            <span class="inbox-item__time"></span>
+            <span class="status-indicator"></span>
+          </div>
+          <p class="inbox-item__title"></p>
+          <div class="inbox-item__meta">
+            <span class="inbox-item__from"></span>
+            <span class="inbox-item__amount"></span>
+          </div>
+          <div class="inbox-item__tags"></div>
+        </button>
+      </li>
+    </template>
+
+    <template id="tagTemplate">
+      <li class="tag-item">
+        <button class="tag-pill" type="button" draggable="true"></button>
+      </li>
+    </template>
+
+    <template id="ocrFieldTemplate">
+      <li class="ocr-field">
+        <article class="ocr-pill">
+          <header class="ocr-pill__header">
+            <span class="ocr-pill__label"></span>
+            <span class="ocr-pill__confidence"></span>
+          </header>
+          <div class="ocr-pill__body">
+            <input class="ocr-pill__input" type="text" />
+            <button class="ocr-pill__confirm" type="button" aria-pressed="false">Confirmer</button>
+          </div>
+        </article>
+      </li>
+    </template>
+
+    <template id="chatMessageTemplate">
+      <li class="chat-message">
+        <div class="chat-bubble">
+          <p class="chat-bubble__text"></p>
+          <span class="chat-bubble__meta"></span>
+        </div>
+      </li>
+    </template>
+
+    <template id="appliedTagTemplate">
+      <button class="applied-tag" type="button" draggable="true"></button>
+    </template>
+
+    <dialog class="modal" id="newInvoiceDialog" aria-labelledby="newInvoiceTitle">
+      <form class="modal__form" id="newInvoiceForm" method="dialog">
+        <header class="modal__header">
+          <h2 id="newInvoiceTitle">Ajouter une facture</h2>
+          <p class="modal__intro">Renseignez les informations essentielles pour ajouter une facture dans l'inbox.</p>
+        </header>
+        <div class="modal__grid">
+          <label class="modal__field">
+            <span>Fournisseur</span>
+            <input type="text" name="vendor" required placeholder="Ex. Hydro-Québec" />
+          </label>
+          <label class="modal__field">
+            <span>Montant (CAD)</span>
+            <input type="number" name="amount" step="0.01" min="0" placeholder="0.00" />
+          </label>
+          <label class="modal__field">
+            <span>Date de facture</span>
+            <input type="date" name="invoiceDate" />
+          </label>
+          <label class="modal__field">
+            <span>Canal</span>
+            <select name="source">
+              <option value="upload">Upload manuel</option>
+              <option value="sms">SMS</option>
+              <option value="email">Courriel</option>
+            </select>
+          </label>
+          <label class="modal__field">
+            <span>Méthode de paiement</span>
+            <input type="text" name="paymentMethod" placeholder="Visa •••• 1234" />
+          </label>
+          <label class="modal__field">
+            <span>URL d'aperçu</span>
+            <input type="url" name="previewUrl" placeholder="https://" />
+          </label>
+          <label class="modal__field">
+            <span>Expéditeur</span>
+            <select name="senderUserId">
+              <option value="">—</option>
+              <option value="user-submit-1">Julien Morin</option>
+              <option value="user-submit-2">Sara Blanchette</option>
+            </select>
+          </label>
+          <label class="modal__field modal__field--wide">
+            <span>Notes</span>
+            <textarea name="notes" rows="3" placeholder="Contexte, projet, instructions"></textarea>
+          </label>
+        </div>
+        <div class="modal__actions">
+          <button type="reset" class="pill-button">Annuler</button>
+          <button type="submit" class="pill-button pill-button--primary">Créer</button>
+        </div>
+      </form>
+    </dialog>
+
+    <script src="src/app.js" type="module"></script>
+  </body>
+</html>

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -1,0 +1,957 @@
+const CURRENT_USER_ID = 'user-tagger';
+const DRAG_MIME = 'application/x-inbox-tag';
+
+const DOM = {
+  invoiceList: document.getElementById('invoiceList'),
+  emptyState: document.getElementById('emptyState'),
+  searchInput: document.getElementById('searchInput'),
+  clearSearchButton: document.getElementById('clearSearchButton'),
+  statusFilter: document.getElementById('statusFilter'),
+  tagFilter: document.getElementById('tagFilter'),
+  periodFilter: document.getElementById('periodFilter'),
+  invoiceVendor: document.getElementById('invoiceVendor'),
+  invoiceSummary: document.getElementById('invoiceSummary'),
+  statusChip: document.getElementById('statusChip'),
+  tagList: document.getElementById('tagList'),
+  addTagButton: document.getElementById('addTagButton'),
+  removeTagDropzone: document.getElementById('removeTagDropzone'),
+  previewStage: document.getElementById('previewStage'),
+  previewMedia: document.getElementById('previewMedia'),
+  previewHint: document.getElementById('previewHint'),
+  appliedTags: document.getElementById('appliedTags'),
+  invoiceChannel: document.getElementById('invoiceChannel'),
+  invoiceTimestamp: document.getElementById('invoiceTimestamp'),
+  sendToReviewButton: document.getElementById('sendToReviewButton'),
+  markCompleteButton: document.getElementById('markCompleteButton'),
+  chatPartner: document.getElementById('chatPartner'),
+  chatMessages: document.getElementById('chatMessages'),
+  chatForm: document.getElementById('chatForm'),
+  chatInput: document.getElementById('chatInput'),
+  ocrFieldList: document.getElementById('ocrFieldList'),
+  toastContainer: document.getElementById('toastContainer'),
+  newUploadButton: document.getElementById('newUploadButton'),
+  newInvoiceDialog: document.getElementById('newInvoiceDialog'),
+  newInvoiceForm: document.getElementById('newInvoiceForm'),
+};
+
+const TEMPLATE = {
+  invoiceRow: document.getElementById('invoiceRowTemplate'),
+  tag: document.getElementById('tagTemplate'),
+  ocrField: document.getElementById('ocrFieldTemplate'),
+  chatMessage: document.getElementById('chatMessageTemplate'),
+  appliedTag: document.getElementById('appliedTagTemplate'),
+};
+
+const state = {
+  tags: [],
+  invoices: [],
+  filters: {
+    search: '',
+    status: 'all',
+    tag: 'all',
+    period: 'all',
+  },
+  selectedInvoiceId: null,
+  selectedInvoice: null,
+  messages: [],
+  chatPoll: null,
+  isCreatingTag: false,
+  dragContext: null,
+};
+
+const API = {
+  async fetchJSON(url, options = {}) {
+    const response = await fetch(url, options);
+    const isJson = response.headers.get('content-type')?.includes('application/json');
+
+    if (!response.ok) {
+      let message = `Erreur ${response.status}`;
+      if (isJson) {
+        try {
+          const payload = await response.json();
+          if (payload?.error) {
+            message = payload.error;
+          }
+        } catch (_) {
+          // ignore JSON parse error
+        }
+      }
+      throw new Error(message);
+    }
+
+    if (!isJson || response.status === 204) {
+      return null;
+    }
+
+    return response.json();
+  },
+  listTags() {
+    return this.fetchJSON('/api/tags');
+  },
+  createTag(payload) {
+    return this.fetchJSON('/api/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  },
+  listInvoices(filters) {
+    const params = new URLSearchParams({
+      search: filters.search || '',
+      status: filters.status || 'all',
+      tag: filters.tag || 'all',
+      period: filters.period || 'all',
+    });
+    return this.fetchJSON(`/api/invoices?${params.toString()}`);
+  },
+  getInvoice(id) {
+    return this.fetchJSON(`/api/invoices/${id}`);
+  },
+  updateInvoice(id, payload) {
+    return this.fetchJSON(`/api/invoices/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  },
+  addTagToInvoice(id, tagId) {
+    return this.fetchJSON(`/api/invoices/${id}/tags`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId, appliedByUserId: CURRENT_USER_ID }),
+    });
+  },
+  removeTagFromInvoice(id, tagId) {
+    return this.fetchJSON(`/api/invoices/${id}/tags/${tagId}`, {
+      method: 'DELETE',
+    });
+  },
+  listMessages(invoiceId) {
+    return this.fetchJSON(`/api/invoices/${invoiceId}/messages`);
+  },
+  createMessage(invoiceId, payload) {
+    return this.fetchJSON(`/api/invoices/${invoiceId}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  },
+  createInvoice(payload) {
+    return this.fetchJSON('/api/invoices', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  },
+};
+
+init().catch((error) => {
+  console.error(error);
+  showToast('Initialisation impossible. Rechargez la page.', { type: 'error' });
+});
+
+async function init() {
+  attachEventListeners();
+  await loadTags();
+  await loadInvoices({ initial: true });
+}
+
+function attachEventListeners() {
+  DOM.searchInput.addEventListener('input', debounce(() => {
+    state.filters.search = DOM.searchInput.value;
+    loadInvoices();
+  }, 250));
+
+  DOM.clearSearchButton.addEventListener('click', () => {
+    DOM.searchInput.value = '';
+    state.filters.search = '';
+    loadInvoices();
+    DOM.searchInput.focus();
+  });
+
+  DOM.statusFilter.addEventListener('change', () => {
+    state.filters.status = DOM.statusFilter.value;
+    loadInvoices();
+  });
+
+  DOM.tagFilter.addEventListener('change', () => {
+    state.filters.tag = DOM.tagFilter.value;
+    loadInvoices();
+  });
+
+  DOM.periodFilter.addEventListener('change', () => {
+    state.filters.period = DOM.periodFilter.value;
+    loadInvoices();
+  });
+
+  DOM.addTagButton.addEventListener('click', () => startTagCreation());
+
+  DOM.previewStage.addEventListener('dragenter', handlePreviewDragEnter);
+  DOM.previewStage.addEventListener('dragover', handlePreviewDragOver);
+  DOM.previewStage.addEventListener('dragleave', handlePreviewDragLeave);
+  DOM.previewStage.addEventListener('drop', handlePreviewDrop);
+
+  DOM.removeTagDropzone.addEventListener('dragenter', handleRemoveDragEnter);
+  DOM.removeTagDropzone.addEventListener('dragover', handleRemoveDragOver);
+  DOM.removeTagDropzone.addEventListener('dragleave', handleRemoveDragLeave);
+  DOM.removeTagDropzone.addEventListener('drop', handleRemoveDrop);
+
+  DOM.sendToReviewButton.addEventListener('click', () => updateStatus('a_verifier'));
+  DOM.markCompleteButton.addEventListener('click', () => {
+    if (!state.selectedInvoice) return;
+    const next = state.selectedInvoice.status === 'complete' ? 'a_verifier' : 'complete';
+    updateStatus(next);
+  });
+
+  DOM.chatForm.addEventListener('submit', handleChatSubmit);
+
+  DOM.newUploadButton.addEventListener('click', () => {
+    if (typeof DOM.newInvoiceDialog.showModal === 'function') {
+      DOM.newInvoiceForm.reset();
+      DOM.newInvoiceDialog.showModal();
+      const firstInput = DOM.newInvoiceForm.querySelector('input, select');
+      if (firstInput) {
+        firstInput.focus();
+      }
+    } else {
+      showToast('Votre navigateur ne supporte pas l’intake manuel.', { type: 'error' });
+    }
+  });
+
+  DOM.newInvoiceForm.addEventListener('submit', handleNewInvoiceSubmit);
+  DOM.newInvoiceForm.addEventListener('reset', () => {
+    setTimeout(() => DOM.newInvoiceDialog.close(), 0);
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.defaultPrevented) return;
+    if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+      return;
+    }
+    if (event.key.toLowerCase() === 't') {
+      focusFirstTag();
+    }
+  });
+}
+
+async function loadTags() {
+  try {
+    state.tags = await API.listTags();
+    renderTagPanel();
+    populateTagFilterOptions();
+  } catch (error) {
+    console.error(error);
+    showToast("Impossible de charger les tags", { type: 'error' });
+  }
+}
+
+async function loadInvoices({ initial = false } = {}) {
+  try {
+    const invoices = await API.listInvoices(state.filters);
+    state.invoices = invoices;
+
+    if (initial && invoices.length > 0) {
+      await selectInvoice(invoices[0].id);
+    } else if (state.selectedInvoiceId) {
+      const stillVisible = invoices.some((invoice) => invoice.id === state.selectedInvoiceId);
+      if (!stillVisible && invoices.length > 0) {
+        await selectInvoice(invoices[0].id);
+      }
+    }
+
+    renderInvoiceList();
+    DOM.emptyState.hidden = state.invoices.length > 0;
+    if (!state.selectedInvoice && state.invoices.length === 0) {
+      renderInvoiceDetail(null);
+    }
+  } catch (error) {
+    console.error(error);
+    showToast("Impossible de charger les factures", { type: 'error' });
+  }
+}
+
+async function selectInvoice(invoiceId) {
+  state.selectedInvoiceId = invoiceId;
+  highlightSelectedInvoice();
+
+  try {
+    toggleDetailLoading(true);
+    const [invoice, messages] = await Promise.all([
+      API.getInvoice(invoiceId),
+      API.listMessages(invoiceId),
+    ]);
+
+    state.selectedInvoice = invoice;
+    state.messages = messages;
+    renderInvoiceDetail(invoice);
+    renderChatMessages(messages);
+    renderTagPanel();
+    toggleDetailLoading(false);
+    startChatPolling();
+  } catch (error) {
+    console.error(error);
+    toggleDetailLoading(false);
+    showToast("Impossible d'ouvrir la facture", { type: 'error' });
+  }
+}
+
+function toggleDetailLoading(isLoading) {
+  DOM.previewStage.classList.toggle('is-loading', isLoading);
+  DOM.chatForm.querySelector('button[type="submit"]').disabled = isLoading;
+}
+
+function highlightSelectedInvoice() {
+  const items = DOM.invoiceList.querySelectorAll('.inbox-item');
+  items.forEach((item) => {
+    const button = item.querySelector('.inbox-item__button');
+    const isSelected = button?.dataset.invoiceId === state.selectedInvoiceId;
+    item.classList.toggle('is-selected', isSelected);
+    if (isSelected) {
+      button.setAttribute('aria-current', 'true');
+    } else {
+      button.removeAttribute('aria-current');
+    }
+  });
+}
+
+function renderInvoiceList() {
+  DOM.invoiceList.innerHTML = '';
+
+  state.invoices.forEach((invoice) => {
+    const entry = TEMPLATE.invoiceRow.content.firstElementChild.cloneNode(true);
+    const button = entry.querySelector('.inbox-item__button');
+    const time = entry.querySelector('.inbox-item__time');
+    const status = entry.querySelector('.status-indicator');
+    const title = entry.querySelector('.inbox-item__title');
+    const from = entry.querySelector('.inbox-item__from');
+    const amount = entry.querySelector('.inbox-item__amount');
+    const tagsContainer = entry.querySelector('.inbox-item__tags');
+
+    button.dataset.invoiceId = invoice.id;
+    button.addEventListener('click', () => selectInvoice(invoice.id));
+
+    entry.classList.toggle('is-selected', invoice.id === state.selectedInvoiceId);
+
+    time.textContent = formatRelativeTime(invoice.createdAt);
+    status.dataset.status = invoice.status;
+    status.textContent = invoice.statusLabel || invoice.status;
+    title.textContent = invoice.vendor || 'Sans fournisseur';
+    from.textContent = buildInvoiceSource(invoice);
+    amount.textContent = invoice.amountTotal ? formatCurrency(invoice.amountTotal) : '—';
+
+    tagsContainer.innerHTML = '';
+    invoice.tags.forEach((tag) => {
+      const badge = document.createElement('span');
+      badge.className = 'tag-badge';
+      badge.textContent = tag.label;
+      tagsContainer.appendChild(badge);
+    });
+
+    DOM.invoiceList.appendChild(entry);
+  });
+
+  highlightSelectedInvoice();
+}
+
+function renderInvoiceDetail(invoice) {
+  if (!invoice) {
+    DOM.invoiceVendor.textContent = 'Sélectionnez une facture';
+    DOM.invoiceSummary.textContent = 'Choisissez un élément dans la liste pour afficher les détails.';
+    DOM.statusChip.textContent = '';
+    DOM.statusChip.removeAttribute('data-status');
+    DOM.previewMedia.style.backgroundImage = '';
+    DOM.previewStage.classList.add('is-empty');
+    DOM.appliedTags.innerHTML = '';
+    DOM.previewHint.hidden = false;
+    DOM.invoiceChannel.textContent = '';
+    DOM.invoiceTimestamp.textContent = '';
+    DOM.chatPartner.textContent = '';
+    DOM.chatInput.disabled = true;
+    DOM.sendToReviewButton.disabled = true;
+    DOM.markCompleteButton.disabled = true;
+    DOM.ocrFieldList.innerHTML = '';
+    DOM.chatMessages.innerHTML = '';
+    return;
+  }
+
+  DOM.invoiceVendor.textContent = invoice.vendor || 'Facture sans fournisseur';
+  DOM.invoiceSummary.textContent = buildInvoiceSummary(invoice);
+  DOM.statusChip.textContent = invoice.statusLabel || invoice.status;
+  DOM.statusChip.dataset.status = invoice.status;
+
+  if (invoice.previewUrl) {
+    DOM.previewMedia.style.backgroundImage = `url(${invoice.previewUrl})`;
+    DOM.previewStage.classList.remove('is-empty');
+  } else {
+    DOM.previewMedia.style.backgroundImage = '';
+    DOM.previewStage.classList.add('is-empty');
+  }
+
+  DOM.previewHint.hidden = invoice.tags.length > 0;
+  renderAppliedTags(invoice);
+
+  DOM.invoiceChannel.textContent = buildInvoiceChannel(invoice);
+  DOM.invoiceTimestamp.textContent = formatDateTime(invoice.createdAt);
+
+  DOM.chatPartner.textContent = invoice.sender?.name || invoice.sender?.email || invoice.sender?.phone || 'Collaborateur externe';
+  DOM.chatInput.disabled = false;
+  DOM.sendToReviewButton.disabled = false;
+  DOM.markCompleteButton.disabled = false;
+  DOM.markCompleteButton.textContent = invoice.status === 'complete' ? 'Repasser en révision' : 'Marquer comme complétée';
+
+  renderOcrFields(invoice);
+}
+
+function renderAppliedTags(invoice) {
+  DOM.appliedTags.innerHTML = '';
+
+  invoice.tags.forEach((tag) => {
+    const button = TEMPLATE.appliedTag.content.firstElementChild.cloneNode(true);
+    button.textContent = tag.label;
+    button.dataset.tagId = tag.tagId;
+    button.draggable = true;
+    button.addEventListener('click', () => removeTag(tag.tagId));
+    button.addEventListener('dragstart', (event) => {
+      state.dragContext = { type: 'applied-tag', tagId: tag.tagId };
+      event.dataTransfer.setData(DRAG_MIME, tag.tagId);
+      event.dataTransfer.effectAllowed = 'move';
+    });
+    button.addEventListener('dragend', () => {
+      state.dragContext = null;
+    });
+    DOM.appliedTags.appendChild(button);
+  });
+}
+
+function renderTagPanel() {
+  DOM.tagList.innerHTML = '';
+  const applied = new Set(state.selectedInvoice?.tags.map((tag) => tag.tagId));
+
+  state.tags.forEach((tag) => {
+    const item = TEMPLATE.tag.content.firstElementChild.cloneNode(true);
+    const button = item.querySelector('.tag-pill');
+    button.textContent = tag.label;
+    button.dataset.tagId = tag.id;
+    button.draggable = true;
+    button.dataset.color = tag.color;
+
+    if (applied.has(tag.id)) {
+      button.classList.add('is-applied');
+    }
+
+    const count = document.createElement('span');
+    count.className = 'tag-pill__count';
+    count.textContent = tag.usageCount?.toString() || '0';
+    button.appendChild(count);
+
+    button.addEventListener('click', () => applyTag(tag.id));
+    button.addEventListener('dragstart', (event) => {
+      state.dragContext = { type: 'tag', tagId: tag.id };
+      event.dataTransfer.setData(DRAG_MIME, tag.id);
+      event.dataTransfer.effectAllowed = 'copy';
+    });
+    button.addEventListener('dragend', () => {
+      state.dragContext = null;
+    });
+
+    DOM.tagList.appendChild(item);
+  });
+}
+
+function renderOcrFields(invoice) {
+  DOM.ocrFieldList.innerHTML = '';
+
+  invoice.ocrFields.forEach((field) => {
+    const entry = TEMPLATE.ocrField.content.firstElementChild.cloneNode(true);
+    const label = entry.querySelector('.ocr-pill__label');
+    const confidence = entry.querySelector('.ocr-pill__confidence');
+    const input = entry.querySelector('.ocr-pill__input');
+    const confirm = entry.querySelector('.ocr-pill__confirm');
+
+    label.textContent = field.label;
+    confidence.textContent = `${Math.round((field.confidence || 0) * 100)}%`;
+    input.value = field.value || '';
+    input.dataset.fieldId = field.id;
+    confirm.dataset.fieldId = field.id;
+    confirm.setAttribute('aria-pressed', field.confirmed ? 'true' : 'false');
+    confirm.classList.toggle('is-active', field.confirmed);
+
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        persistOcrField(field.id, { value: input.value.trim() });
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        input.value = field.value || '';
+        input.blur();
+      }
+    });
+
+    input.addEventListener('blur', () => {
+      if (input.value.trim() !== field.value) {
+        persistOcrField(field.id, { value: input.value.trim() });
+      }
+    });
+
+    confirm.addEventListener('click', () => {
+      persistOcrField(field.id, { confirmed: !field.confirmed });
+    });
+
+    DOM.ocrFieldList.appendChild(entry);
+  });
+}
+
+function renderChatMessages(messages) {
+  DOM.chatMessages.innerHTML = '';
+  if (!state.selectedInvoice) return;
+
+  messages.forEach((message) => {
+    const entry = TEMPLATE.chatMessage.content.firstElementChild.cloneNode(true);
+    const bubbleText = entry.querySelector('.chat-bubble__text');
+    const bubbleMeta = entry.querySelector('.chat-bubble__meta');
+
+    const isCurrent = message.fromUserId === CURRENT_USER_ID;
+    entry.dataset.direction = isCurrent ? 'outgoing' : 'incoming';
+
+    bubbleText.textContent = message.body;
+    const author = isCurrent ? 'Vous' : message.authorName;
+    bubbleMeta.textContent = `${author} · ${formatTime(message.createdAt)}`;
+
+    DOM.chatMessages.appendChild(entry);
+  });
+
+  DOM.chatMessages.scrollTop = DOM.chatMessages.scrollHeight;
+}
+
+function populateTagFilterOptions() {
+  const current = DOM.tagFilter.value;
+  DOM.tagFilter.innerHTML = '';
+  const defaultOption = document.createElement('option');
+  defaultOption.value = 'all';
+  defaultOption.textContent = 'Tous les tags';
+  DOM.tagFilter.appendChild(defaultOption);
+
+  state.tags.forEach((tag) => {
+    const option = document.createElement('option');
+    option.value = tag.id;
+    option.textContent = tag.label;
+    DOM.tagFilter.appendChild(option);
+  });
+
+  DOM.tagFilter.value = state.tags.some((tag) => tag.id === current) ? current : 'all';
+}
+
+function startTagCreation() {
+  if (state.isCreatingTag) return;
+  state.isCreatingTag = true;
+
+  const item = document.createElement('li');
+  item.className = 'tag-item';
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'tag-edit-input';
+  input.placeholder = 'Nouveau tag';
+  input.setAttribute('aria-label', 'Nom du nouveau tag');
+  item.appendChild(input);
+  DOM.tagList.prepend(item);
+  input.focus();
+
+  const finalize = async (value) => {
+    const label = value.trim();
+    if (!label) {
+      DOM.tagList.removeChild(item);
+      state.isCreatingTag = false;
+      return;
+    }
+
+    try {
+      const tag = await API.createTag({ label });
+      state.tags.push({ ...tag, usageCount: 0 });
+      state.tags.sort((a, b) => a.label.localeCompare(b.label));
+      renderTagPanel();
+      populateTagFilterOptions();
+      showToast(`Tag "${tag.label}" créé`);
+    } catch (error) {
+      console.error(error);
+      showToast(error.message || 'Impossible de créer le tag', { type: 'error' });
+    } finally {
+      state.isCreatingTag = false;
+    }
+  };
+
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      finalize(input.value);
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      DOM.tagList.removeChild(item);
+      state.isCreatingTag = false;
+    }
+  });
+
+  input.addEventListener('blur', () => finalize(input.value));
+}
+
+async function applyTag(tagId) {
+  if (!state.selectedInvoice) return;
+  try {
+    const updated = await API.addTagToInvoice(state.selectedInvoice.id, tagId);
+    mergeInvoice(updated);
+    showToast('Tag appliqué');
+  } catch (error) {
+    console.error(error);
+    showToast(error.message || "Impossible d'appliquer le tag", { type: 'error' });
+  }
+}
+
+async function removeTag(tagId) {
+  if (!state.selectedInvoice) return;
+  try {
+    const response = await API.removeTagFromInvoice(state.selectedInvoice.id, tagId);
+    if (!response?.invoice) return;
+    mergeInvoice(response.invoice);
+    showToast('Tag retiré', {
+      action: {
+        label: 'Annuler',
+        handler: () => applyTag(tagId),
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    showToast(error.message || "Impossible de retirer le tag", { type: 'error' });
+  }
+}
+
+async function updateStatus(status) {
+  if (!state.selectedInvoice) return;
+  try {
+    const updated = await API.updateInvoice(state.selectedInvoice.id, { status });
+    mergeInvoice(updated);
+    showToast(`Statut → ${updated.statusLabel || status}`);
+  } catch (error) {
+    console.error(error);
+    showToast(error.message || 'Changement de statut impossible', { type: 'error' });
+  }
+}
+
+async function persistOcrField(fieldId, updates) {
+  if (!state.selectedInvoice) return;
+  const fields = state.selectedInvoice.ocrFields.map((field) =>
+    field.id === fieldId ? { ...field, ...updates } : field,
+  );
+  try {
+    const updated = await API.updateInvoice(state.selectedInvoice.id, { ocrFields: fields });
+    mergeInvoice(updated);
+    showToast('Champ mis à jour');
+  } catch (error) {
+    console.error(error);
+    showToast(error.message || 'Erreur de sauvegarde OCR', { type: 'error' });
+  }
+}
+
+async function handleChatSubmit(event) {
+  event.preventDefault();
+  if (!state.selectedInvoice) return;
+  const value = DOM.chatInput.value.trim();
+  if (!value) return;
+
+  DOM.chatInput.disabled = true;
+  try {
+    const message = await API.createMessage(state.selectedInvoice.id, {
+      body: value,
+      fromUserId: CURRENT_USER_ID,
+    });
+    state.messages.push(message);
+    renderChatMessages(state.messages);
+    DOM.chatInput.value = '';
+  } catch (error) {
+    console.error(error);
+    showToast(error.message || "Impossible d'envoyer le message", { type: 'error' });
+  } finally {
+    DOM.chatInput.disabled = false;
+    DOM.chatInput.focus();
+  }
+}
+
+async function handleNewInvoiceSubmit(event) {
+  event.preventDefault();
+  const form = event.target;
+  const formData = new FormData(form);
+
+  const payload = {
+    vendor: formData.get('vendor')?.trim(),
+    amountTotal: parseFloat(formData.get('amount') || '0'),
+    invoiceDate: formData.get('invoiceDate') || null,
+    source: formData.get('source') || 'upload',
+    paymentMethod: formData.get('paymentMethod')?.trim() || '',
+    previewUrl: formData.get('previewUrl')?.trim() || '',
+    notes: formData.get('notes')?.trim() || '',
+    senderUserId: formData.get('senderUserId') || null,
+  };
+
+  if (!payload.vendor) {
+    showToast('Le fournisseur est requis', { type: 'error' });
+    return;
+  }
+
+  try {
+    const invoice = await API.createInvoice(payload);
+    showToast('Facture ajoutée');
+    DOM.newInvoiceDialog.close();
+    await loadInvoices();
+    if (invoice?.id) {
+      await selectInvoice(invoice.id);
+    }
+  } catch (error) {
+    console.error(error);
+    showToast(error.message || 'Impossible de créer la facture', { type: 'error' });
+  }
+}
+
+function mergeInvoice(updated) {
+  if (!updated) return;
+  const index = state.invoices.findIndex((invoice) => invoice.id === updated.id);
+  if (index !== -1) {
+    state.invoices[index] = updated;
+  }
+  if (state.selectedInvoice?.id === updated.id) {
+    state.selectedInvoice = updated;
+  }
+  renderInvoiceList();
+  renderInvoiceDetail(state.selectedInvoice);
+}
+
+function startChatPolling() {
+  if (state.chatPoll) {
+    clearInterval(state.chatPoll);
+  }
+  if (!state.selectedInvoiceId) return;
+
+  state.chatPoll = setInterval(async () => {
+    try {
+      const messages = await API.listMessages(state.selectedInvoiceId);
+      if (JSON.stringify(messages) !== JSON.stringify(state.messages)) {
+        state.messages = messages;
+        renderChatMessages(messages);
+      }
+    } catch (error) {
+      clearInterval(state.chatPoll);
+      state.chatPoll = null;
+    }
+  }, 5000);
+}
+
+function focusFirstTag() {
+  const tag = DOM.tagList.querySelector('.tag-pill');
+  if (tag) {
+    tag.focus();
+  }
+}
+
+function handlePreviewDragEnter(event) {
+  if (!acceptsTagDrag(event)) return;
+  event.preventDefault();
+  DOM.previewStage.classList.add('is-target');
+}
+
+function handlePreviewDragOver(event) {
+  if (!acceptsTagDrag(event)) return;
+  event.preventDefault();
+  event.dataTransfer.dropEffect = 'copy';
+}
+
+function handlePreviewDragLeave(event) {
+  if (!acceptsTagDrag(event)) return;
+  if (event.target === DOM.previewStage) {
+    DOM.previewStage.classList.remove('is-target');
+  }
+}
+
+function handlePreviewDrop(event) {
+  if (!acceptsTagDrag(event)) return;
+  event.preventDefault();
+  DOM.previewStage.classList.remove('is-target');
+  const tagId = event.dataTransfer.getData(DRAG_MIME) || state.dragContext?.tagId;
+  if (tagId) {
+    applyTag(tagId);
+  }
+}
+
+function handleRemoveDragEnter(event) {
+  if (!acceptsAppliedTagDrag(event)) return;
+  event.preventDefault();
+  DOM.removeTagDropzone.classList.add('is-target');
+}
+
+function handleRemoveDragOver(event) {
+  if (!acceptsAppliedTagDrag(event)) return;
+  event.preventDefault();
+  event.dataTransfer.dropEffect = 'move';
+}
+
+function handleRemoveDragLeave(event) {
+  if (!acceptsAppliedTagDrag(event)) return;
+  if (event.target === DOM.removeTagDropzone) {
+    DOM.removeTagDropzone.classList.remove('is-target');
+  }
+}
+
+function handleRemoveDrop(event) {
+  if (!acceptsAppliedTagDrag(event)) return;
+  event.preventDefault();
+  DOM.removeTagDropzone.classList.remove('is-target');
+  const tagId = event.dataTransfer.getData(DRAG_MIME) || state.dragContext?.tagId;
+  if (tagId) {
+    removeTag(tagId);
+  }
+}
+
+function acceptsTagDrag(event) {
+  if (!state.selectedInvoice) return false;
+  const data = event.dataTransfer.types;
+  return data?.includes(DRAG_MIME);
+}
+
+function acceptsAppliedTagDrag(event) {
+  return acceptsTagDrag(event) && state.dragContext?.type === 'applied-tag';
+}
+
+function buildInvoiceSource(invoice) {
+  const channel = invoice.source ? invoice.source.toUpperCase() : 'INCONNU';
+  if (invoice.sender?.name) {
+    return `${channel} · ${invoice.sender.name}`;
+  }
+  if (invoice.senderEmail) {
+    return `${channel} · ${invoice.senderEmail}`;
+  }
+  if (invoice.senderPhone) {
+    return `${channel} · ${invoice.senderPhone}`;
+  }
+  return channel;
+}
+
+function buildInvoiceSummary(invoice) {
+  const parts = [];
+  if (invoice.amountTotal) {
+    parts.push(formatCurrency(invoice.amountTotal));
+  }
+  if (invoice.invoiceDate) {
+    parts.push(formatDate(invoice.invoiceDate));
+  }
+  if (invoice.paymentMethod) {
+    parts.push(invoice.paymentMethod);
+  }
+  return parts.join(' · ');
+}
+
+function buildInvoiceChannel(invoice) {
+  const channelMap = {
+    sms: 'Reçue par SMS',
+    email: 'Reçue par courriel',
+    upload: 'Import manuel',
+  };
+  const label = channelMap[invoice.source] || 'Source inconnue';
+  if (invoice.sender?.name) {
+    return `${label} · ${invoice.sender.name}`;
+  }
+  if (invoice.senderEmail) {
+    return `${label} · ${invoice.senderEmail}`;
+  }
+  if (invoice.senderPhone) {
+    return `${label} · ${invoice.senderPhone}`;
+  }
+  return label;
+}
+
+function formatCurrency(value) {
+  return new Intl.NumberFormat('fr-CA', {
+    style: 'currency',
+    currency: 'CAD',
+  }).format(value);
+}
+
+function formatDate(value) {
+  if (!value) return '';
+  return new Intl.DateTimeFormat('fr-CA', { dateStyle: 'medium' }).format(new Date(value));
+}
+
+function formatDateTime(value) {
+  if (!value) return '';
+  return new Intl.DateTimeFormat('fr-CA', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+function formatTime(value) {
+  if (!value) return '';
+  return new Intl.DateTimeFormat('fr-CA', { timeStyle: 'short' }).format(new Date(value));
+}
+
+function formatRelativeTime(value) {
+  if (!value) return '';
+  const now = Date.now();
+  const time = new Date(value).getTime();
+  const diff = time - now;
+  const abs = Math.abs(diff);
+  const units = [
+    { unit: 'day', ms: 86_400_000 },
+    { unit: 'hour', ms: 3_600_000 },
+    { unit: 'minute', ms: 60_000 },
+  ];
+  for (const { unit, ms } of units) {
+    if (abs >= ms || unit === 'minute') {
+      const formatter = new Intl.RelativeTimeFormat('fr', { numeric: 'auto' });
+      return formatter.format(Math.round(diff / ms), unit);
+    }
+  }
+  return '';
+}
+
+function debounce(fn, wait = 200) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), wait);
+  };
+}
+
+function showToast(message, { type = 'info', action } = {}) {
+  const toast = document.createElement('div');
+  toast.className = `toast toast--${type}`;
+  const messageEl = document.createElement('span');
+  messageEl.className = 'toast__message';
+  messageEl.textContent = message;
+  toast.appendChild(messageEl);
+
+  if (action) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'toast__action';
+    button.textContent = action.label;
+    button.addEventListener('click', () => {
+      action.handler?.();
+      toast.remove();
+    });
+    toast.appendChild(button);
+  }
+
+  DOM.toastContainer.appendChild(toast);
+  setTimeout(() => {
+    toast.classList.add('is-visible');
+  }, 10);
+
+  setTimeout(() => {
+    toast.classList.remove('is-visible');
+    setTimeout(() => toast.remove(), 300);
+  }, 6000);
+}
+
+window.addEventListener('beforeunload', () => {
+  if (state.chatPoll) {
+    clearInterval(state.chatPoll);
+  }
+});

--- a/public/src/styles.css
+++ b/public/src/styles.css
@@ -1,0 +1,1275 @@
+:root {
+  color-scheme: dark;
+  --bg-900: #11131a;
+  --bg-800: #161922;
+  --bg-700: #1c1f2a;
+  --bg-600: #212536;
+  --bg-500: #272c3f;
+  --bg-400: #2d3248;
+  --bg-300: #32395a;
+  --bg-translucent: rgba(25, 28, 40, 0.76);
+  --border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f7f7fb;
+  --text-secondary: rgba(247, 247, 251, 0.72);
+  --text-muted: rgba(247, 247, 251, 0.56);
+  --accent-green: #3fd680;
+  --accent-green-strong: #30b86b;
+  --accent-red: #ff5f5f;
+  --accent-blue: #4f8bff;
+  --accent-orange: #ff9f45;
+  --accent-neutral: #8c8fa3;
+  --shadow-soft: 0 18px 48px rgba(6, 7, 12, 0.45);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --radius-xs: 8px;
+  --transition: 0.24s ease;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "SF Pro Text", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at top, #1c2237 0%, #0d0f15 40%, #05060a 100%);
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+  display: flex;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(ellipse at top right, rgba(79, 139, 255, 0.12), transparent 55%),
+    radial-gradient(ellipse at bottom left, rgba(63, 214, 128, 0.12), transparent 50%);
+  z-index: 0;
+}
+
+.app {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex: 1;
+  min-height: 100vh;
+  width: 100%;
+  overflow: hidden;
+}
+
+.primary-rail {
+  width: 92px;
+  padding: 32px 12px 24px;
+  background: linear-gradient(180deg, rgba(32, 35, 52, 0.88), rgba(18, 20, 31, 0.94));
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.primary-rail__brand {
+  font-weight: 700;
+  letter-spacing: 0.38em;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.brand-mark {
+  display: inline-block;
+  padding: 12px 10px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 16px 28px rgba(0, 0, 0, 0.35);
+}
+
+.primary-rail__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: stretch;
+  width: 100%;
+}
+
+.rail-button,
+.upload-button {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+  border-radius: 18px;
+  padding: 12px 0;
+  width: 100%;
+  font-size: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: transform var(--transition), background var(--transition), border var(--transition);
+}
+
+.rail-button span[aria-hidden="true"],
+.upload-button span[aria-hidden="true"] {
+  font-size: 1.3rem;
+}
+
+.rail-button:hover,
+.upload-button:hover,
+.rail-button:focus-visible,
+.upload-button:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.rail-button.is-active {
+  background: rgba(63, 214, 128, 0.16);
+  border-color: rgba(63, 214, 128, 0.35);
+  color: #d5ffe9;
+}
+
+.primary-rail__actions {
+  margin-top: auto;
+  width: 100%;
+}
+
+.workspace {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  backdrop-filter: blur(18px);
+}
+
+.workspace__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 28px 40px 24px;
+  background: rgba(16, 19, 29, 0.9);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  gap: 24px;
+}
+
+.search-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 280px;
+}
+
+.field {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 16px;
+  height: 46px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  width: clamp(240px, 42vw, 400px);
+  transition: border var(--transition), box-shadow var(--transition);
+}
+
+.field:focus-within {
+  border-color: rgba(79, 139, 255, 0.65);
+  box-shadow: 0 0 0 3px rgba(79, 139, 255, 0.18);
+}
+
+.field__icon {
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.field input {
+  background: transparent;
+  border: 0;
+  outline: none;
+  color: inherit;
+  font-size: 0.95rem;
+  width: 100%;
+}
+
+.field input::placeholder {
+  color: var(--text-muted);
+}
+
+.ghost-button {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  padding: 8px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+}
+
+.filter-group {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.filter {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.filter select {
+  min-width: 160px;
+  padding: 10px 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  transition: border var(--transition);
+}
+
+.filter select:focus-visible {
+  border-color: rgba(79, 139, 255, 0.65);
+}
+
+.workspace__body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+  gap: 24px;
+  padding: 28px 40px 32px;
+  overflow: hidden;
+}
+
+.inbox {
+  display: flex;
+  flex-direction: column;
+  background: rgba(18, 21, 32, 0.88);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.inbox__header {
+  padding: 22px 28px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.inbox__header h1 {
+  font-size: 1.4rem;
+  margin: 0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.inbox__hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.inbox__list {
+  margin: 0;
+  padding: 8px 0 6px;
+  list-style: none;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.inbox-item {
+  margin: 0;
+  padding: 0 16px;
+}
+
+.inbox-item__button {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  border-radius: 16px;
+  padding: 14px 18px 16px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto auto;
+  gap: 8px 16px;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+  text-align: left;
+}
+
+.inbox-item__button:hover,
+.inbox-item__button:focus-visible {
+  background: rgba(255, 255, 255, 0.06);
+  transform: translateY(-1px);
+}
+
+.inbox-item.is-selected .inbox-item__button {
+  background: rgba(79, 139, 255, 0.16);
+  border: 1px solid rgba(79, 139, 255, 0.35);
+}
+
+.inbox-item__top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  grid-column: 1 / -1;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.status-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-transform: uppercase;
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+}
+
+.status-indicator::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-neutral);
+}
+
+.status-indicator[data-status="nouvelle"]::before {
+  background: var(--accent-orange);
+}
+
+.status-indicator[data-status="a_verifier"]::before {
+  background: var(--accent-blue);
+}
+
+.status-indicator[data-status="complete"]::before {
+  background: var(--accent-green);
+}
+
+.status-indicator[data-status="archive"]::before {
+  background: var(--accent-neutral);
+}
+
+.status-indicator[data-status="ocr_error"]::before {
+  background: var(--accent-red);
+}
+
+.inbox-item__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.inbox-item__meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.inbox-item__amount {
+  margin-left: auto;
+  font-weight: 600;
+  color: #d6deff;
+}
+
+.inbox-item__tags {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag-badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.empty-state {
+  padding: 20px 28px 32px;
+  margin: 0;
+  color: var(--text-muted);
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.invoice {
+  background: rgba(15, 18, 28, 0.9);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.invoice__header {
+  padding: 24px 32px 18px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.invoice__vendor {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.invoice__summary {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  max-width: 520px;
+}
+
+.invoice__status {
+  align-self: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.invoice__columns {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr) 260px;
+  gap: 24px;
+  padding: 24px 32px 30px;
+  min-height: 0;
+}
+
+.tag-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.tag-panel__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: stretch;
+}
+
+.tag-button {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  border-radius: var(--radius-md);
+  height: 52px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  font-size: 1.4rem;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: transform var(--transition), background var(--transition), border var(--transition);
+}
+
+.tag-button--add {
+  background: rgba(63, 214, 128, 0.16);
+  color: #bfffe0;
+  border: 1px solid rgba(63, 214, 128, 0.4);
+}
+
+.tag-button--remove {
+  position: relative;
+  background: rgba(255, 95, 95, 0.14);
+  color: #ffd1d1;
+  border: 1px dashed rgba(255, 95, 95, 0.4);
+  flex-direction: column;
+  font-size: 1.8rem;
+  padding-top: 4px;
+}
+
+.tag-button__label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: 6px;
+}
+
+.tag-button--remove.is-target,
+.preview__stage.is-target {
+  border-color: rgba(255, 255, 255, 0.6);
+  box-shadow: 0 0 0 3px rgba(79, 139, 255, 0.35);
+}
+
+.tag-button:hover,
+.tag-button:focus-visible {
+  transform: translateY(-2px);
+  border-style: solid;
+}
+
+.tag-panel__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: calc(100vh - 320px);
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.tag-item {
+  display: flex;
+}
+
+.tag-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.75rem;
+  cursor: grab;
+  gap: 8px;
+  width: 100%;
+  min-height: 44px;
+  transition: border var(--transition), background var(--transition), color var(--transition);
+}
+
+.tag-pill__count {
+  margin-left: auto;
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.tag-pill:active {
+  cursor: grabbing;
+}
+
+.tag-pill.is-applied {
+  background: rgba(79, 139, 255, 0.2);
+  border-color: rgba(79, 139, 255, 0.45);
+  color: #d6e4ff;
+}
+
+.tag-pill.is-new {
+  background: rgba(255, 255, 255, 0.08);
+  border-style: dashed;
+}
+
+.tag-pill:focus-visible {
+  outline: none;
+  border-color: rgba(79, 139, 255, 0.6);
+  box-shadow: 0 0 0 3px rgba(79, 139, 255, 0.26);
+}
+
+.tag-pill__color {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.8;
+}
+
+.tag-edit-input {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(9, 11, 20, 0.4);
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.preview {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-height: 0;
+}
+
+.preview__stage {
+  position: relative;
+  background: linear-gradient(180deg, rgba(40, 45, 68, 0.75), rgba(16, 18, 28, 0.85));
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  min-height: 420px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.preview__media {
+  position: absolute;
+  inset: 0;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  opacity: 0.92;
+  filter: saturate(0.95);
+}
+
+.preview__stage.is-empty .preview__media {
+  background: linear-gradient(135deg, rgba(60, 65, 95, 0.6), rgba(30, 34, 52, 0.6));
+}
+
+.preview__hint {
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(6px);
+  padding: 6px 18px;
+  border-radius: 999px;
+  background: rgba(10, 12, 20, 0.4);
+}
+
+.preview__stage.is-target {
+  border-style: solid;
+  background: rgba(79, 139, 255, 0.1);
+}
+
+.preview__stage.is-empty::before {
+  content: "Aperçu";
+  position: absolute;
+  font-size: 1.1rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.28);
+}
+
+.applied-tags {
+  position: absolute;
+  inset: 18px;
+  display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  gap: 10px;
+}
+
+.applied-tag {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(0, 0, 0, 0.38);
+  border-radius: 999px;
+  color: #f0f5ff;
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 8px 14px;
+  cursor: grab;
+  transition: transform var(--transition), background var(--transition);
+}
+
+.applied-tag:focus-visible,
+.applied-tag:hover {
+  transform: translateY(-2px);
+  background: rgba(79, 139, 255, 0.45);
+}
+
+.review-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(18, 22, 34, 0.92);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 16px 20px;
+  gap: 18px;
+}
+
+.review-bar__info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.review-bar__info strong {
+  color: var(--text-primary);
+}
+
+.review-bar__channel {
+  margin: 0;
+  font-weight: 500;
+}
+
+.review-bar__time {
+  margin: 0;
+}
+
+.review-bar__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.pill-button {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  padding: 10px 20px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--transition), border var(--transition), transform var(--transition);
+}
+
+.pill-button--primary {
+  background: linear-gradient(135deg, #ffb368, #ff7a42);
+  border-color: rgba(255, 179, 104, 0.5);
+  color: #1b0e00;
+}
+
+.pill-button:hover,
+.pill-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.chat {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background: rgba(14, 17, 27, 0.92);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 18px 18px 20px;
+  min-height: 0;
+}
+
+.chat__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.chat__header h2 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.chat__partner {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.chat__messages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 240px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.chat-message {
+  display: flex;
+}
+
+.chat-message[data-direction="outgoing"] {
+  justify-content: flex-end;
+}
+
+.chat-bubble {
+  max-width: 72%;
+  padding: 12px 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(8px);
+  display: inline-flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-message[data-direction="outgoing"] .chat-bubble {
+  background: linear-gradient(135deg, rgba(79, 139, 255, 0.85), rgba(63, 214, 128, 0.85));
+  color: #081123;
+}
+
+.chat-bubble__text {
+  margin: 0;
+  line-height: 1.4;
+}
+
+.chat-bubble__meta {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.chat-message[data-direction="outgoing"] .chat-bubble__meta {
+  color: rgba(8, 17, 35, 0.7);
+}
+
+.chat__composer {
+  display: flex;
+  gap: 12px;
+}
+
+.chat__input {
+  flex: 1;
+}
+
+.chat__input input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+}
+
+.ocr-panel {
+  background: rgba(14, 17, 27, 0.92);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 18px 18px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 0;
+}
+
+.ocr-panel__header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.ocr-panel__hint {
+  margin: 4px 0 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.ocr-panel__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.ocr-pill {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 16px;
+  padding: 12px 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.ocr-pill__header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.ocr-pill__confidence {
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
+.ocr-pill.is-low-confidence .ocr-pill__confidence {
+  color: var(--accent-orange);
+}
+
+.ocr-pill__body {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.ocr-pill__input {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.28);
+  color: var(--text-primary);
+}
+
+.ocr-pill__input:focus-visible {
+  border-color: rgba(79, 139, 255, 0.6);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(79, 139, 255, 0.22);
+}
+
+.ocr-pill__confirm {
+  border-radius: 999px;
+  padding: 8px 14px;
+  border: 1px solid rgba(79, 139, 255, 0.6);
+  background: rgba(79, 139, 255, 0.15);
+  color: #d9e6ff;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.ocr-pill__confirm.is-confirmed {
+  background: rgba(63, 214, 128, 0.24);
+  border-color: rgba(63, 214, 128, 0.6);
+  color: #c9ffde;
+}
+
+.ocr-pill__confirm:hover,
+.ocr-pill__confirm:focus-visible {
+  transform: translateY(-1px);
+}
+
+.toast-container {
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.toast {  
+  display: inline-flex;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 20px;
+  border-radius: 999px;
+  background: rgba(15, 18, 30, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.45);
+  pointer-events: auto;
+}
+
+.toast--error {
+  border-color: rgba(248, 113, 113, 0.4);
+  background: rgba(44, 14, 20, 0.92);
+}
+
+.toast--success {
+  border-color: rgba(34, 197, 94, 0.45);
+  background: rgba(14, 36, 24, 0.9);
+}
+
+.toast__message {
+  font-size: 0.85rem;
+}
+
+.toast__action {
+  border: none;
+  background: none;
+  color: #aaccff;
+  font-weight: 600;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.toast__action:hover,
+.toast__action:focus-visible {
+  text-decoration: underline;
+}
+
+.modal {
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0;
+  width: min(520px, 90vw);
+  background: rgba(9, 11, 20, 0.94);
+  color: var(--text-primary);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+}
+
+.modal::backdrop {
+  background: rgba(6, 8, 16, 0.65);
+  backdrop-filter: blur(4px);
+}
+
+.modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 26px 32px;
+}
+
+.modal__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.modal__intro {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.modal__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.modal__field--wide {
+  grid-column: 1 / -1;
+}
+
+.modal__field span {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.modal__field input,
+.modal__field select,
+.modal__field textarea {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(13, 16, 28, 0.6);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.modal__field textarea {
+  resize: vertical;
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.scrollbar::-webkit-scrollbar {
+  width: 8px;
+}
+
+.inbox__list::-webkit-scrollbar,
+.tag-panel__list::-webkit-scrollbar,
+.chat__messages::-webkit-scrollbar,
+.ocr-panel__list::-webkit-scrollbar {
+  width: 8px;
+}
+
+.inbox__list::-webkit-scrollbar-thumb,
+.tag-panel__list::-webkit-scrollbar-thumb,
+.chat__messages::-webkit-scrollbar-thumb,
+.ocr-panel__list::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+}
+
+@media (max-width: 1380px) {
+  .workspace__body {
+    grid-template-columns: 320px minmax(0, 1fr);
+    padding: 24px 28px 28px;
+  }
+
+  .invoice__columns {
+    grid-template-columns: 200px minmax(0, 1fr) 240px;
+  }
+
+  .tag-button {
+    height: 48px;
+  }
+}
+
+@media (max-width: 1220px) {
+  .workspace__body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .inbox {
+    height: 320px;
+  }
+
+  .invoice {
+    min-height: 540px;
+  }
+
+  .invoice__columns {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .tag-panel,
+  .ocr-panel {
+    flex-direction: row;
+    overflow-x: auto;
+  }
+
+  .tag-panel {
+    order: 1;
+  }
+
+  .preview {
+    order: 2;
+  }
+
+  .ocr-panel {
+    order: 3;
+  }
+
+  .tag-panel__list {
+    flex-direction: row;
+    flex-wrap: wrap;
+    max-height: none;
+  }
+
+  .tag-item {
+    flex: 0 0 auto;
+  }
+
+  .ocr-panel__list {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .ocr-pill {
+    min-width: 240px;
+  }
+}
+
+@media (max-width: 980px) {
+  .app {
+    flex-direction: column;
+  }
+
+  .primary-rail {
+    flex-direction: row;
+    width: 100%;
+    padding: 18px 24px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+  }
+
+  .primary-rail__nav {
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .rail-button,
+  .upload-button {
+    flex-direction: row;
+    gap: 10px;
+    padding: 10px 14px;
+  }
+
+  .workspace__header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+    padding: 20px 24px;
+  }
+
+  .workspace__body {
+    padding: 20px 24px 24px;
+  }
+}
+
+@media (max-width: 720px) {
+  .filter-group {
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .filter select {
+    min-width: 140px;
+  }
+
+  .review-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .review-bar__actions {
+    justify-content: space-between;
+  }
+
+  .chat__messages {
+    max-height: 200px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition: none !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,528 @@
+const http = require('http');
+const path = require('path');
+const { readFile, writeFile, stat } = require('fs/promises');
+const { randomUUID } = require('crypto');
+
+const PORT = process.env.PORT || 4173;
+const ORG_ID = 'org-demo';
+const DB_PATH = path.join(__dirname, 'data', 'db.json');
+const PUBLIC_DIR = path.join(__dirname, 'public');
+
+const STATUS_LABEL = {
+  nouvelle: 'Nouvelle',
+  a_verifier: 'À vérifier',
+  complete: 'Complète',
+  archive: 'Archivée',
+  ocr_error: 'Erreur OCR',
+};
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+  '.ttf': 'font/ttf',
+};
+
+const routes = [
+  { method: 'GET', pattern: /^\/api\/tags$/, handler: getTags },
+  { method: 'POST', pattern: /^\/api\/tags$/, handler: createTag },
+  { method: 'DELETE', pattern: /^\/api\/tags\/([^/]+)$/, handler: deleteTag },
+  { method: 'GET', pattern: /^\/api\/invoices$/, handler: listInvoices },
+  { method: 'POST', pattern: /^\/api\/invoices$/, handler: createInvoice },
+  { method: 'GET', pattern: /^\/api\/invoices\/([^/]+)$/, handler: getInvoice },
+  { method: 'PATCH', pattern: /^\/api\/invoices\/([^/]+)$/, handler: patchInvoice },
+  { method: 'POST', pattern: /^\/api\/invoices\/([^/]+)\/tags$/, handler: addInvoiceTag },
+  { method: 'DELETE', pattern: /^\/api\/invoices\/([^/]+)\/tags\/([^/]+)$/, handler: removeInvoiceTag },
+  { method: 'GET', pattern: /^\/api\/invoices\/([^/]+)\/messages$/, handler: listMessages },
+  { method: 'POST', pattern: /^\/api\/invoices\/([^/]+)\/messages$/, handler: createMessage },
+];
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.url.startsWith('/api/')) {
+      await handleApi(req, res);
+    } else {
+      await serveStatic(req, res);
+    }
+  } catch (error) {
+    console.error('Unexpected error', error);
+    sendJson(res, 500, { error: 'Erreur interne du serveur' });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Inbox server running on http://localhost:${PORT}`);
+});
+
+async function handleApi(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  for (const route of routes) {
+    if (req.method !== route.method) continue;
+    const match = url.pathname.match(route.pattern);
+    if (match) {
+      const params = match.slice(1);
+      await route.handler(req, res, params, url.searchParams);
+      return;
+    }
+  }
+  sendJson(res, 404, { error: 'Route inconnue' });
+}
+
+async function serveStatic(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  let pathname = decodeURIComponent(url.pathname);
+  if (pathname === '/') {
+    pathname = '/index.html';
+  }
+  const filePath = path.join(PUBLIC_DIR, pathname);
+  if (!filePath.startsWith(PUBLIC_DIR)) {
+    sendText(res, 403, 'Accès refusé');
+    return;
+  }
+
+  try {
+    const fileStat = await stat(filePath);
+    if (fileStat.isDirectory()) {
+      await serveFile(path.join(filePath, 'index.html'), res);
+    } else {
+      await serveFile(filePath, res);
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      // SPA fallback for routes without extension
+      if (!path.extname(pathname)) {
+        await serveFile(path.join(PUBLIC_DIR, 'index.html'), res);
+        return;
+      }
+      sendText(res, 404, 'Fichier introuvable');
+    } else {
+      console.error(error);
+      sendText(res, 500, 'Erreur de lecture de fichier');
+    }
+  }
+}
+
+async function serveFile(filePath, res) {
+  const data = await readFile(filePath);
+  const ext = path.extname(filePath);
+  const type = MIME_TYPES[ext] || 'application/octet-stream';
+  res.writeHead(200, { 'Content-Type': type });
+  res.end(data);
+}
+
+async function loadDb() {
+  const content = await readFile(DB_PATH, 'utf-8');
+  return JSON.parse(content);
+}
+
+async function saveDb(db) {
+  await writeFile(DB_PATH, JSON.stringify(db, null, 2), 'utf-8');
+}
+
+function buildMaps(db) {
+  const tagMap = new Map(db.tags.map((tag) => [tag.id, tag]));
+  const userMap = new Map(db.users.map((user) => [user.id, user]));
+  return { tagMap, userMap };
+}
+
+function decorateInvoice(invoice, db) {
+  const { tagMap, userMap } = buildMaps(db);
+  const sender = invoice.senderUserId ? userMap.get(invoice.senderUserId) : null;
+
+  return {
+    ...invoice,
+    statusLabel: STATUS_LABEL[invoice.status] || invoice.status,
+    sender: sender
+      ? {
+          id: sender.id,
+          name: sender.name,
+          email: sender.email,
+          phone: sender.phone,
+          role: sender.role,
+        }
+      : null,
+    tags: invoice.tags.map((link) => {
+      const tag = tagMap.get(link.tagId);
+      const user = userMap.get(link.appliedByUserId);
+      return {
+        tagId: link.tagId,
+        label: tag ? tag.label : 'Tag supprimé',
+        color: tag ? tag.color : '#777',
+        appliedByUserId: link.appliedByUserId,
+        appliedByName: user ? user.name : 'Inconnu',
+        createdAt: link.createdAt,
+      };
+    }),
+  };
+}
+
+function decorateMessage(message, db) {
+  const { userMap } = buildMaps(db);
+  const author = message.fromUserId ? userMap.get(message.fromUserId) : null;
+
+  return {
+    ...message,
+    authorName: author ? author.name : message.fromExternalPhone || 'Système',
+    authorRole: author ? author.role : 'external',
+  };
+}
+
+function computeTagUsage(db) {
+  const usage = Object.fromEntries(db.tags.map((tag) => [tag.id, 0]));
+  for (const invoice of db.invoices) {
+    for (const link of invoice.tags) {
+      if (usage[link.tagId] !== undefined) {
+        usage[link.tagId] += 1;
+      }
+    }
+  }
+  return usage;
+}
+
+function matchesFilters(invoice, db, { search, status, tag, period }) {
+  if (status && status !== 'all' && invoice.status !== status) {
+    return false;
+  }
+  if (tag && tag !== 'all' && !invoice.tags.some((link) => link.tagId === tag)) {
+    return false;
+  }
+  if (period && period !== 'all') {
+    const createdAt = new Date(invoice.createdAt);
+    const now = new Date();
+    const diffMs = now - createdAt;
+    const dayMs = 24 * 60 * 60 * 1000;
+    if (period === 'today' && createdAt.toDateString() !== now.toDateString()) {
+      return false;
+    }
+    if (period === '7d' && diffMs > 7 * dayMs) {
+      return false;
+    }
+    if (period === '30d' && diffMs > 30 * dayMs) {
+      return false;
+    }
+  }
+  if (search) {
+    const { tagMap, userMap } = buildMaps(db);
+    const invoiceText = [
+      invoice.vendor,
+      invoice.senderEmail,
+      invoice.senderPhone,
+      invoice.amountTotal ? invoice.amountTotal.toString() : '',
+      invoice.invoiceDate,
+      invoice.status,
+      ...invoice.tags.map((link) => {
+        const tagEntry = tagMap.get(link.tagId);
+        return tagEntry ? tagEntry.label : '';
+      }),
+      (() => {
+        const user = userMap.get(invoice.senderUserId);
+        return user ? user.name : '';
+      })(),
+    ]
+      .join(' ')
+      .toLowerCase();
+    if (!invoiceText.includes(search.toLowerCase())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function getTags(req, res) {
+  const db = await loadDb();
+  const usage = computeTagUsage(db);
+  const tags = db.tags
+    .filter((tag) => tag.orgId === ORG_ID)
+    .map((tag) => ({
+      ...tag,
+      usageCount: usage[tag.id] ?? 0,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+  sendJson(res, 200, tags);
+}
+
+async function createTag(req, res) {
+  const body = await readJsonBody(req, res);
+  if (!body) return;
+  const { label, color = '#4f46e5', createdByUserId = null } = body;
+  if (!label || typeof label !== 'string' || !label.trim()) {
+    sendJson(res, 400, { error: 'Label requis' });
+    return;
+  }
+  const normalized = label.trim();
+  const db = await loadDb();
+  const exists = db.tags.some(
+    (tag) => tag.orgId === ORG_ID && tag.label.toLowerCase() === normalized.toLowerCase(),
+  );
+  if (exists) {
+    sendJson(res, 409, { error: 'Ce tag existe déjà' });
+    return;
+  }
+  const tag = {
+    id: `tag-${randomUUID()}`,
+    orgId: ORG_ID,
+    label: normalized,
+    color,
+    isSystem: false,
+    createdAt: new Date().toISOString(),
+    createdByUserId,
+  };
+  db.tags.push(tag);
+  await saveDb(db);
+  sendJson(res, 201, tag);
+}
+
+async function deleteTag(req, res, params) {
+  const [id] = params;
+  const db = await loadDb();
+  const usage = computeTagUsage(db);
+  if ((usage[id] ?? 0) > 0) {
+    sendJson(res, 409, { error: 'Tag utilisé sur des factures' });
+    return;
+  }
+  const index = db.tags.findIndex((tag) => tag.id === id && tag.orgId === ORG_ID);
+  if (index === -1) {
+    sendJson(res, 404, { error: 'Tag introuvable' });
+    return;
+  }
+  const [removed] = db.tags.splice(index, 1);
+  await saveDb(db);
+  sendJson(res, 200, removed);
+}
+
+async function listInvoices(req, res, _params, searchParams) {
+  const search = searchParams.get('search') || '';
+  const status = searchParams.get('status') || 'all';
+  const tag = searchParams.get('tag') || 'all';
+  const period = searchParams.get('period') || 'all';
+
+  const db = await loadDb();
+  const invoices = db.invoices
+    .filter((invoice) => invoice.orgId === ORG_ID)
+    .filter((invoice) => matchesFilters(invoice, db, { search, status, tag, period }))
+    .map((invoice) => decorateInvoice(invoice, db))
+    .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+
+  sendJson(res, 200, invoices);
+}
+
+async function getInvoice(req, res, params) {
+  const [id] = params;
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === id && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+  sendJson(res, 200, decorateInvoice(invoice, db));
+}
+
+async function patchInvoice(req, res, params) {
+  const [id] = params;
+  const body = await readJsonBody(req, res);
+  if (!body) return;
+
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === id && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+
+  const allowed = new Set(['vendor', 'amountTotal', 'invoiceDate', 'status', 'paymentMethod', 'ocrFields']);
+  Object.entries(body).forEach(([key, value]) => {
+    if (allowed.has(key)) {
+      invoice[key] = value;
+    }
+  });
+  invoice.updatedAt = new Date().toISOString();
+  await saveDb(db);
+  sendJson(res, 200, decorateInvoice(invoice, db));
+}
+
+async function createInvoice(req, res) {
+  const body = await readJsonBody(req, res);
+  if (!body) return;
+  const {
+    vendor,
+    amountTotal,
+    invoiceDate,
+    senderUserId,
+    source = 'upload',
+    paymentMethod = '',
+    previewUrl = '',
+    notes = '',
+  } = body;
+
+  if (!vendor) {
+    sendJson(res, 400, { error: 'Fournisseur requis' });
+    return;
+  }
+
+  const db = await loadDb();
+  const invoice = {
+    id: `inv-${randomUUID()}`,
+    orgId: ORG_ID,
+    senderUserId: senderUserId || null,
+    source,
+    originalFilename: null,
+    driveFileId: null,
+    driveFileUrl: null,
+    previewUrl,
+    amountTotal: amountTotal !== undefined && amountTotal !== null ? Number(amountTotal) : null,
+    invoiceDate: invoiceDate || null,
+    vendor,
+    paymentMethod,
+    status: 'nouvelle',
+    notes,
+    tags: [],
+    ocrFields: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  db.invoices.push(invoice);
+  await saveDb(db);
+  sendJson(res, 201, decorateInvoice(invoice, db));
+}
+
+async function addInvoiceTag(req, res, params) {
+  const [invoiceId] = params;
+  const body = await readJsonBody(req, res);
+  if (!body) return;
+  const { tagId, appliedByUserId = null } = body;
+  if (!tagId) {
+    sendJson(res, 400, { error: 'tagId requis' });
+    return;
+  }
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === invoiceId && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+  const hasTag = invoice.tags.some((link) => link.tagId === tagId);
+  if (!hasTag) {
+    invoice.tags.push({
+      tagId,
+      appliedByUserId,
+      createdAt: new Date().toISOString(),
+    });
+    invoice.updatedAt = new Date().toISOString();
+    await saveDb(db);
+  }
+  sendJson(res, 200, decorateInvoice(invoice, db));
+}
+
+async function removeInvoiceTag(req, res, params) {
+  const [invoiceId, tagId] = params;
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === invoiceId && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+  const index = invoice.tags.findIndex((link) => link.tagId === tagId);
+  if (index === -1) {
+    sendJson(res, 404, { error: 'Tag non appliqué' });
+    return;
+  }
+  const [removed] = invoice.tags.splice(index, 1);
+  invoice.updatedAt = new Date().toISOString();
+  await saveDb(db);
+  sendJson(res, 200, { removed, invoice: decorateInvoice(invoice, db) });
+}
+
+async function listMessages(req, res, params) {
+  const [invoiceId] = params;
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === invoiceId && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+  const messages = db.messages
+    .filter((message) => message.invoiceId === invoiceId)
+    .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+    .map((message) => decorateMessage(message, db));
+  sendJson(res, 200, messages);
+}
+
+async function createMessage(req, res, params) {
+  const [invoiceId] = params;
+  const body = await readJsonBody(req, res);
+  if (!body) return;
+  const { body: messageBody, fromUserId = null, fromExternalPhone = null, attachments = [] } = body;
+  if (!messageBody || typeof messageBody !== 'string' || !messageBody.trim()) {
+    sendJson(res, 400, { error: 'Message vide' });
+    return;
+  }
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === invoiceId && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+  const message = {
+    id: `msg-${randomUUID()}`,
+    invoiceId,
+    fromUserId,
+    fromExternalPhone,
+    body: messageBody.trim(),
+    attachments,
+    sentVia: fromExternalPhone ? 'sms' : 'inapp',
+    deliveryStatus: 'sent',
+    createdAt: new Date().toISOString(),
+  };
+  db.messages.push(message);
+  invoice.updatedAt = new Date().toISOString();
+  await saveDb(db);
+  sendJson(res, 201, decorateMessage(message, db));
+}
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function sendText(res, statusCode, message) {
+  res.writeHead(statusCode, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end(message);
+}
+
+async function readJsonBody(req, res) {
+  try {
+    const raw = await readBody(req);
+    if (!raw) return {};
+    return JSON.parse(raw);
+  } catch (error) {
+    sendJson(res, 400, { error: 'JSON invalide' });
+    return null;
+  }
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req
+      .on('data', (chunk) => {
+        chunks.push(chunk);
+      })
+      .on('end', () => {
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      })
+      .on('error', reject);
+  });
+}


### PR DESCRIPTION
## Summary
- replace the static prototype with a Node.js HTTP server that serves the UI and exposes the invoice, tag and chat REST API
- seed a persistent demo dataset (org, users, invoices, tags, messages) and document the new workflow in the README
- rebuild the front-end to fetch live data, support drag-and-drop tagging, OCR edits, chat polling and a modal intake form wired to the API

## Testing
- `node server.js`
- `python - <<'PY' ...` (fetch invoice details)
- `python - <<'PY' ...` (apply tag via API)


------
https://chatgpt.com/codex/tasks/task_e_68c89e1795fc8321af97aacb1ffed7eb