### PR TITLE
Add drag-and-drop tagging with undo to Inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,67 @@
-# Inbox
+# InBox – application prototype
 
-Welcome to the new Inbox web app.
-InBox create a single place to store all your document. It as simple as send everything from message text and email. No app to install! Just add the Inbox email adress and phone number to your contact and, that's it!! Send everything that is important for future retrieve and review. Access all your document trew the web app interface, that will let you tag everything easily to organize your documents. Or give access to your assistant! So he can review everyth
+Cette version fournit une application fonctionnelle et stable pour explorer les parcours décrits dans la spécification Inbox : consultation des factures, application de tags, échanges de messages et création d'éléments depuis l'interface. L'accent est mis sur la fiabilité : le serveur embarqué expose une API REST simple, l'interface consomme systématiquement cette API et une suite de tests de bout en bout valide les opérations critiques.
 
-## Features
-- Organize tasks and messages
-- Prioritize important items
-- User-friendly interface
+## Démarrage rapide
 
-Feel free to explore the code, contribute, and make this project even better!
-## Features
-- Organize tasks and messages
-- Prioritize important items
-- User-friendly interface
+```bash
+# Depuis la racine du dépôt
+npm test        # lance la batterie de tests API sur une copie jetable de la base de données
+npm start       # démarre le serveur sur http://localhost:4173
+```
 
-Feel free to explore the code, contribute, and make this project even better!
+Aucune dépendance externe n'est requise : Node.js (≥ 18) suffit pour exécuter le serveur et la suite de tests. Le fichier `data/db.json` sert de persistance JSON; il est automatiquement copié dans un emplacement temporaire lors des tests pour préserver l'état de développement.
+
+## Fonctionnalités couvertes
+
+- **Liste et filtres** – Recherche plein texte, filtres par statut, tag et période alimentent la route `GET /api/invoices`. La liste se met à jour instantanément et affiche montant, fournisseur, date et statut.
+- **Vue détail** – Sélectionner une facture charge ses métadonnées (`GET /api/invoices/{id}`), l'aperçu, les champs OCR et l'expéditeur. Le statut peut être modifié via un sélecteur (`PATCH /api/invoices/{id}`).
+- **Tags** – Le panneau latéral montre les tags globaux et leur compteur d'utilisation. Dans la vue détail, on peut appliquer un tag au clavier, par clic ou par glisser-déposer vers l'aperçu (et le retirer en le déposant sur la zone « − Supprimer »). Chaque action affiche un toast avec possibilité d'annuler pendant 8 secondes (`POST`/`DELETE /api/invoices/{id}/tags/{tagId}`).
+- **Chat** – Chaque facture dispose d'un fil de discussion (`GET/POST /api/invoices/{id}/messages`). Les messages sont horodatés et indiquent l'auteur.
+- **Création de facture** – Le bouton « Ajouter une facture » ouvre une modale accessible. La soumission crée l'élément côté serveur (`POST /api/invoices`) puis sélectionne automatiquement la nouvelle facture.
+- **Gestion des tags** – Le bouton « ＋ » révèle un formulaire inline pour créer un tag (`POST /api/tags`). La liste et les filtres sont actualisés immédiatement.
+
+## Structure du projet
+
+```
+public/
+  index.html      # Layout 3 colonnes, formulaires et templates
+  src/app.js      # Logique frontend (fetch API, rendu, toasts)
+  src/styles.css  # Thème sombre responsive et composants
+server.js         # Serveur HTTP + API REST + fichiers statiques
+data/db.json      # Jeu de données de démonstration
+tests/api.test.js # Tests API end-to-end (création tag/facture, chat, tagging)
+```
+
+## API REST
+
+| Méthode | Route | Description |
+| --- | --- | --- |
+| GET | `/api/tags` | Liste les tags avec compteur d'usage |
+| POST | `/api/tags` | Crée un tag |
+| DELETE | `/api/tags/{id}` | Supprime un tag non utilisé |
+| GET | `/api/invoices` | Liste les factures filtrables |
+| POST | `/api/invoices` | Crée une facture manuelle |
+| GET | `/api/invoices/{id}` | Retourne la facture enrichie (tags, expéditeur) |
+| PATCH | `/api/invoices/{id}` | Met à jour les champs autorisés (statut, OCR) |
+| POST | `/api/invoices/{id}/tags` | Applique un tag |
+| DELETE | `/api/invoices/{id}/tags/{tagId}` | Retire un tag |
+| GET | `/api/invoices/{id}/messages` | Récupère le fil de discussion |
+| POST | `/api/invoices/{id}/messages` | Ajoute un message |
+
+Toutes les routes sont protégées par l'organisation fictive `org-demo` et renvoient des structures enrichies (`statusLabel`, `authorName`, etc.) pour simplifier le rendu côté client.
+
+## Stratégie de test
+
+La commande `npm test` démarre une instance du serveur sur un port aléatoire en pointant vers une copie temporaire de `data/db.json`. Les tests vérifient :
+
+1. Le chargement des tags et la création/suppression d'un tag.
+2. La création d'une facture et sa récupération immédiate.
+3. L'envoi d'un message dans le chat de la nouvelle facture.
+4. L'application d'un tag existant sur cette facture.
+
+Ce flux reproduit les interactions clés de l'interface et garantit que la base de données réelle reste intacte.
+
+## Licence
+
+MIT

--- a/data/db.json
+++ b/data/db.json
@@ -1,0 +1,325 @@
+{
+  "orgs": [
+    {
+      "id": "org-demo",
+      "name": "Coop Atlas"
+    }
+  ],
+  "users": [
+    {
+      "id": "user-admin",
+      "orgId": "org-demo",
+      "name": "Amélie Dufresne",
+      "email": "amelie@coopatlas.ca",
+      "phone": "+15145550111",
+      "role": "admin",
+      "status": "active",
+      "notificationPreferences": {
+        "sms": true,
+        "email": true
+      }
+    },
+    {
+      "id": "user-tagger",
+      "orgId": "org-demo",
+      "name": "Léa Gervais",
+      "email": "lea@coopatlas.ca",
+      "phone": "+15145550145",
+      "role": "tagger",
+      "status": "active",
+      "notificationPreferences": {
+        "sms": true,
+        "email": true
+      }
+    },
+    {
+      "id": "user-submit-1",
+      "orgId": "org-demo",
+      "name": "Julien Morin",
+      "email": "julien@coopatlas.ca",
+      "phone": "+15145550187",
+      "role": "submitter",
+      "status": "active",
+      "notificationPreferences": {
+        "sms": true,
+        "email": false
+      }
+    },
+    {
+      "id": "user-submit-2",
+      "orgId": "org-demo",
+      "name": "Sara Blanchette",
+      "email": "sara@coopatlas.ca",
+      "phone": "+15145550162",
+      "role": "submitter",
+      "status": "active",
+      "notificationPreferences": {
+        "sms": false,
+        "email": true
+      }
+    }
+  ],
+  "tags": [
+    {
+      "id": "tag-fuel",
+      "orgId": "org-demo",
+      "label": "Essence",
+      "color": "#f97316",
+      "isSystem": false,
+      "createdAt": "2024-02-01T13:05:00.000Z",
+      "createdByUserId": "user-admin"
+    },
+    {
+      "id": "tag-meal",
+      "orgId": "org-demo",
+      "label": "Repas",
+      "color": "#ec4899",
+      "isSystem": false,
+      "createdAt": "2024-02-14T09:12:00.000Z",
+      "createdByUserId": "user-admin"
+    },
+    {
+      "id": "tag-card",
+      "orgId": "org-demo",
+      "label": "Carte de crédit",
+      "color": "#22d3ee",
+      "isSystem": true,
+      "createdAt": "2024-02-19T08:30:00.000Z",
+      "createdByUserId": "user-admin"
+    },
+    {
+      "id": "tag-to-review",
+      "orgId": "org-demo",
+      "label": "À approuver",
+      "color": "#a855f7",
+      "isSystem": false,
+      "createdAt": "2024-03-04T11:45:00.000Z",
+      "createdByUserId": "user-tagger"
+    }
+  ],
+  "invoices": [
+    {
+      "id": "inv-gas-001",
+      "orgId": "org-demo",
+      "senderUserId": "user-submit-1",
+      "senderPhone": "+15145550187",
+      "source": "sms",
+      "originalFilename": "IMG_3421.jpg",
+      "driveFileId": "drive-1001",
+      "driveFileUrl": "https://drive.google.com/file/d/drive-1001",
+      "previewUrl": "https://images.unsplash.com/photo-1529429617124-aee1114814c4?auto=format&fit=crop&w=800&q=80",
+      "vendor": "Shell Canada",
+      "invoiceDate": "2024-03-04",
+      "amountTotal": 82.31,
+      "tps": 3.44,
+      "tvq": 6.87,
+      "paymentMethod": "Visa •••• 1234",
+      "status": "a_verifier",
+      "notes": "Plein d'essence camion livraison",
+      "tags": [
+        {
+          "tagId": "tag-fuel",
+          "appliedByUserId": "user-tagger",
+          "createdAt": "2024-03-05T14:30:00.000Z"
+        },
+        {
+          "tagId": "tag-card",
+          "appliedByUserId": "user-tagger",
+          "createdAt": "2024-03-05T14:30:10.000Z"
+        }
+      ],
+      "ocrFields": [
+        {
+          "id": "vendor",
+          "label": "Fournisseur",
+          "value": "Shell Canada",
+          "confidence": 0.78,
+          "confirmed": true
+        },
+        {
+          "id": "invoiceDate",
+          "label": "Date",
+          "value": "2024-03-04",
+          "confidence": 0.82,
+          "confirmed": false
+        },
+        {
+          "id": "amountTotal",
+          "label": "Montant",
+          "value": "82.31",
+          "confidence": 0.93,
+          "confirmed": true
+        },
+        {
+          "id": "tps",
+          "label": "TPS",
+          "value": "3.44",
+          "confidence": 0.74,
+          "confirmed": false
+        },
+        {
+          "id": "tvq",
+          "label": "TVQ",
+          "value": "6.87",
+          "confidence": 0.69,
+          "confirmed": false
+        },
+        {
+          "id": "paymentMethod",
+          "label": "Paiement",
+          "value": "Visa •••• 1234",
+          "confidence": 0.55,
+          "confirmed": false
+        }
+      ],
+      "createdAt": "2024-03-04T22:20:00.000Z",
+      "updatedAt": "2024-03-05T14:30:10.000Z"
+    },
+    {
+      "id": "inv-meal-002",
+      "orgId": "org-demo",
+      "senderUserId": "user-submit-2",
+      "senderEmail": "sara@coopatlas.ca",
+      "source": "email",
+      "originalFilename": "BonRestaurant.pdf",
+      "driveFileId": "drive-1002",
+      "driveFileUrl": "https://drive.google.com/file/d/drive-1002",
+      "previewUrl": "https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=800&q=80",
+      "vendor": "Bistro Limoilou",
+      "invoiceDate": "2024-03-02",
+      "amountTotal": 128.5,
+      "tps": 5.12,
+      "tvq": 10.27,
+      "paymentMethod": "Mastercard •••• 8876",
+      "status": "complete",
+      "notes": "Repas client - Projet Atlas",
+      "tags": [
+        {
+          "tagId": "tag-meal",
+          "appliedByUserId": "user-tagger",
+          "createdAt": "2024-03-03T11:05:00.000Z"
+        },
+        {
+          "tagId": "tag-card",
+          "appliedByUserId": "user-tagger",
+          "createdAt": "2024-03-03T11:05:04.000Z"
+        }
+      ],
+      "ocrFields": [
+        {
+          "id": "vendor",
+          "label": "Fournisseur",
+          "value": "Bistro Limoilou",
+          "confidence": 0.91,
+          "confirmed": true
+        },
+        {
+          "id": "invoiceDate",
+          "label": "Date",
+          "value": "2024-03-02",
+          "confidence": 0.86,
+          "confirmed": true
+        },
+        {
+          "id": "amountTotal",
+          "label": "Montant",
+          "value": "128.50",
+          "confidence": 0.94,
+          "confirmed": true
+        },
+        {
+          "id": "paymentMethod",
+          "label": "Paiement",
+          "value": "Mastercard •••• 8876",
+          "confidence": 0.68,
+          "confirmed": false
+        }
+      ],
+      "createdAt": "2024-03-02T20:12:00.000Z",
+      "updatedAt": "2024-03-03T11:05:04.000Z"
+    },
+    {
+      "id": "inv-saas-003",
+      "orgId": "org-demo",
+      "senderUserId": "user-submit-1",
+      "senderEmail": "julien@coopatlas.ca",
+      "source": "upload",
+      "originalFilename": "Invoice_March.pdf",
+      "driveFileId": "drive-1003",
+      "driveFileUrl": "https://drive.google.com/file/d/drive-1003",
+      "previewUrl": "https://images.unsplash.com/photo-1587613865525-5d0aeaa8c1ae?auto=format&fit=crop&w=800&q=80",
+      "vendor": "Figma",
+      "invoiceDate": "2024-03-01",
+      "amountTotal": 45,
+      "tps": 0,
+      "tvq": 0,
+      "paymentMethod": "Carte Visa •••• 1234",
+      "status": "nouvelle",
+      "notes": "Abonnement mensuel équipe design",
+      "tags": [
+        {
+          "tagId": "tag-card",
+          "appliedByUserId": "user-admin",
+          "createdAt": "2024-03-01T09:00:00.000Z"
+        }
+      ],
+      "ocrFields": [
+        {
+          "id": "vendor",
+          "label": "Fournisseur",
+          "value": "Figma",
+          "confidence": 0.95,
+          "confirmed": true
+        },
+        {
+          "id": "invoiceDate",
+          "label": "Date",
+          "value": "2024-03-01",
+          "confidence": 0.89,
+          "confirmed": true
+        },
+        {
+          "id": "amountTotal",
+          "label": "Montant",
+          "value": "45.00",
+          "confidence": 0.97,
+          "confirmed": true
+        }
+      ],
+      "createdAt": "2024-03-01T09:00:00.000Z",
+      "updatedAt": "2025-09-16T03:49:27.968Z"
+    }
+  ],
+  "messages": [
+    {
+      "id": "msg-1",
+      "invoiceId": "inv-gas-001",
+      "fromUserId": "user-tagger",
+      "body": "Salut Julien! Peux-tu confirmer que c'est bien pour le camion de Québec?",
+      "attachments": [],
+      "sentVia": "inapp",
+      "deliveryStatus": "delivered",
+      "createdAt": "2024-03-05T14:32:00.000Z"
+    },
+    {
+      "id": "msg-2",
+      "invoiceId": "inv-gas-001",
+      "fromExternalPhone": "+15145550187",
+      "body": "Oui c'est pour la tournée de Québec, merci!",
+      "attachments": [],
+      "sentVia": "sms",
+      "deliveryStatus": "delivered",
+      "createdAt": "2024-03-05T14:35:00.000Z"
+    },
+    {
+      "id": "msg-3",
+      "invoiceId": "inv-meal-002",
+      "fromUserId": "user-tagger",
+      "body": "Pense à ajouter le détail du client sur la note de frais svp",
+      "attachments": [],
+      "sentVia": "inapp",
+      "deliveryStatus": "delivered",
+      "createdAt": "2024-03-03T11:05:30.000Z"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "inbox",
+  "version": "1.0.0",
+  "description": "Inbox – centralisation des factures (prototype fonctionnel)",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node tests/api.test.js"
+  },
+  "keywords": [
+    "inbox",
+    "factures",
+    "ocr",
+    "tags"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>InBox — Gestion des factures</title>
+    <link rel="stylesheet" href="src/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="app-header__title">
+        <h1>InBox</h1>
+        <p>Centralisez, classez et suivez toutes vos factures.</p>
+      </div>
+      <div class="app-header__actions">
+        <button id="openUploadDialog" class="primary-button">Ajouter une facture</button>
+      </div>
+    </header>
+
+    <div class="app-grid">
+      <aside class="sidebar" aria-label="Tags disponibles">
+        <div class="sidebar__header">
+          <h2>Tags</h2>
+          <button id="toggleTagForm" class="icon-button" aria-label="Créer un nouveau tag">＋</button>
+        </div>
+        <form id="tagForm" class="tag-form" hidden>
+          <label for="tagLabel" class="tag-form__label">Nom du tag</label>
+          <input id="tagLabel" name="label" type="text" placeholder="Ex. Essence" required />
+          <div class="tag-form__row">
+            <label for="tagColor">Couleur</label>
+            <input id="tagColor" name="color" type="color" value="#5b5bd6" />
+          </div>
+          <div class="tag-form__actions">
+            <button type="button" class="ghost-button" id="cancelTagForm">Annuler</button>
+            <button type="submit" class="primary-button">Créer</button>
+          </div>
+        </form>
+        <ul id="tagList" class="tag-list" role="list"></ul>
+      </aside>
+
+      <main class="workspace" aria-label="Liste des factures">
+        <section class="filters" aria-label="Filtres de recherche">
+          <label class="filters__field">
+            <span>Recherche</span>
+            <input id="searchInput" type="search" placeholder="Fournisseur, montant, date…" autocomplete="off" />
+          </label>
+          <label class="filters__field">
+            <span>Statut</span>
+            <select id="statusFilter">
+              <option value="all">Tous</option>
+              <option value="nouvelle">Nouvelle</option>
+              <option value="a_verifier">À vérifier</option>
+              <option value="complete">Complète</option>
+              <option value="archive">Archivée</option>
+              <option value="ocr_error">Erreur OCR</option>
+            </select>
+          </label>
+          <label class="filters__field">
+            <span>Tag</span>
+            <select id="tagFilter">
+              <option value="all">Tous</option>
+            </select>
+          </label>
+          <label class="filters__field">
+            <span>Période</span>
+            <select id="periodFilter">
+              <option value="all">Toute période</option>
+              <option value="today">Aujourd'hui</option>
+              <option value="7d">7 derniers jours</option>
+              <option value="30d">30 derniers jours</option>
+            </select>
+          </label>
+        </section>
+
+        <section class="invoice-list" aria-live="polite">
+          <ul id="invoiceList" role="list"></ul>
+          <p id="emptyState" class="empty" hidden>Aucune facture ne correspond à vos filtres.</p>
+        </section>
+      </main>
+
+      <aside class="detail" aria-live="polite">
+        <div id="detailEmpty" class="detail-empty">
+          <h2>Sélectionnez une facture</h2>
+          <p>Choisissez une facture dans la liste pour voir ses détails.</p>
+        </div>
+        <div id="detailContent" class="detail-content" hidden>
+          <header class="detail__header">
+            <div>
+              <h2 id="detailVendor"></h2>
+              <p id="detailSummary"></p>
+            </div>
+            <div class="status">
+              <label for="statusSelect">Statut</label>
+              <select id="statusSelect"></select>
+            </div>
+          </header>
+          <div class="preview" id="preview"></div>
+          <section class="detail__section">
+            <h3>Tags appliqués</h3>
+            <div id="appliedTags" class="tag-chips" aria-label="Tags appliqués"></div>
+            <div class="tag-drop-actions">
+              <p class="detail__hint tag-drop-actions__hint">
+                Glissez un tag sur l'aperçu pour l'appliquer, ou déposez un tag existant sur le bouton ci-dessous pour le
+                retirer.
+              </p>
+              <button
+                type="button"
+                id="removeTagDropzone"
+                class="dropzone dropzone--remove"
+                aria-label="Retirer un tag"
+                aria-disabled="true"
+              >
+                <span aria-hidden="true">−</span>
+                Supprimer
+              </button>
+            </div>
+            <div class="tag-chips tag-chips--picker" id="tagPicker" aria-label="Ajouter un tag"></div>
+          </section>
+          <section class="detail__section">
+            <h3>Champs extraits</h3>
+            <ul id="ocrList" class="ocr-list"></ul>
+          </section>
+          <section class="detail__section">
+            <h3>Chat</h3>
+            <p id="chatPartner" class="chat-partner"></p>
+            <ul id="chatList" class="chat-list" role="list"></ul>
+            <form id="chatForm" class="chat-form">
+              <label class="chat-form__field" for="chatInput">Votre message</label>
+              <input id="chatInput" name="message" type="text" autocomplete="off" placeholder="Poser une question…" required />
+              <button type="submit" class="primary-button">Envoyer</button>
+            </form>
+          </section>
+        </div>
+      </aside>
+    </div>
+
+    <dialog id="uploadDialog" aria-labelledby="uploadDialogTitle">
+      <form id="uploadForm" class="modal" method="dialog">
+        <h2 id="uploadDialogTitle">Ajouter une facture</h2>
+        <p class="modal__intro">Complétez les informations pour créer une facture.</p>
+        <label class="modal__field">
+          <span>Fournisseur</span>
+          <input name="vendor" type="text" placeholder="Ex. Hydro-Québec" required />
+        </label>
+        <label class="modal__field">
+          <span>Montant (CAD)</span>
+          <input name="amountTotal" type="number" min="0" step="0.01" placeholder="0.00" />
+        </label>
+        <label class="modal__field">
+          <span>Date de facture</span>
+          <input name="invoiceDate" type="date" />
+        </label>
+        <label class="modal__field">
+          <span>Canal</span>
+          <select name="source">
+            <option value="upload">Upload manuel</option>
+            <option value="sms">SMS</option>
+            <option value="email">Courriel</option>
+          </select>
+        </label>
+        <label class="modal__field">
+          <span>Méthode de paiement</span>
+          <input name="paymentMethod" type="text" placeholder="Visa ••••" />
+        </label>
+        <label class="modal__field">
+          <span>URL d'aperçu</span>
+          <input name="previewUrl" type="url" placeholder="https://" />
+        </label>
+        <label class="modal__field">
+          <span>Expéditeur</span>
+          <select name="senderUserId">
+            <option value="">—</option>
+            <option value="user-submit-1">Julien Morin</option>
+            <option value="user-submit-2">Sara Blanchette</option>
+          </select>
+        </label>
+        <label class="modal__field">
+          <span>Notes</span>
+          <textarea name="notes" rows="3" placeholder="Contexte ou instructions"></textarea>
+        </label>
+        <div class="modal__actions">
+          <button type="reset" class="ghost-button">Annuler</button>
+          <button type="submit" class="primary-button">Créer</button>
+        </div>
+      </form>
+    </dialog>
+
+    <div id="toast" class="toast" role="status" aria-live="assertive">
+      <span id="toastMessage"></span>
+      <button id="toastAction" type="button" class="toast__action" aria-hidden="true"></button>
+    </div>
+
+    <template id="invoiceItemTemplate">
+      <li class="invoice-item">
+        <button type="button" class="invoice-item__button">
+          <div class="invoice-item__primary">
+            <span class="invoice-item__vendor"></span>
+            <span class="invoice-item__amount"></span>
+          </div>
+          <div class="invoice-item__meta">
+            <span class="invoice-item__date"></span>
+            <span class="invoice-item__status"></span>
+          </div>
+        </button>
+      </li>
+    </template>
+
+    <template id="tagTemplate">
+      <li class="tag-list__item">
+        <span class="tag-list__color"></span>
+        <span class="tag-list__label"></span>
+        <span class="tag-list__count"></span>
+      </li>
+    </template>
+
+    <script type="module" src="src/app.js"></script>
+  </body>
+</html>

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -1,0 +1,1018 @@
+const CURRENT_USER_ID = 'user-tagger';
+const STATUS_OPTIONS = [
+  { value: 'nouvelle', label: 'Nouvelle' },
+  { value: 'a_verifier', label: 'À vérifier' },
+  { value: 'complete', label: 'Complète' },
+  { value: 'archive', label: 'Archivée' },
+  { value: 'ocr_error', label: 'Erreur OCR' },
+];
+
+const DOM = {
+  invoiceList: document.getElementById('invoiceList'),
+  invoiceTemplate: document.getElementById('invoiceItemTemplate'),
+  tagTemplate: document.getElementById('tagTemplate'),
+  tagList: document.getElementById('tagList'),
+  tagFilter: document.getElementById('tagFilter'),
+  statusFilter: document.getElementById('statusFilter'),
+  periodFilter: document.getElementById('periodFilter'),
+  searchInput: document.getElementById('searchInput'),
+  emptyState: document.getElementById('emptyState'),
+  detailEmpty: document.getElementById('detailEmpty'),
+  detailContent: document.getElementById('detailContent'),
+  detailVendor: document.getElementById('detailVendor'),
+  detailSummary: document.getElementById('detailSummary'),
+  statusSelect: document.getElementById('statusSelect'),
+  preview: document.getElementById('preview'),
+  appliedTags: document.getElementById('appliedTags'),
+  tagPicker: document.getElementById('tagPicker'),
+  ocrList: document.getElementById('ocrList'),
+  chatPartner: document.getElementById('chatPartner'),
+  chatList: document.getElementById('chatList'),
+  chatForm: document.getElementById('chatForm'),
+  chatInput: document.getElementById('chatInput'),
+  toast: document.getElementById('toast'),
+  toastMessage: document.getElementById('toastMessage'),
+  toastAction: document.getElementById('toastAction'),
+  openUploadDialog: document.getElementById('openUploadDialog'),
+  uploadDialog: document.getElementById('uploadDialog'),
+  uploadForm: document.getElementById('uploadForm'),
+  tagForm: document.getElementById('tagForm'),
+  toggleTagForm: document.getElementById('toggleTagForm'),
+  cancelTagForm: document.getElementById('cancelTagForm'),
+  removeTagDropzone: document.getElementById('removeTagDropzone'),
+};
+
+const state = {
+  tags: [],
+  invoices: [],
+  filters: {
+    search: '',
+    status: 'all',
+    tag: 'all',
+    period: 'all',
+  },
+  selectedInvoiceId: null,
+  selectedInvoice: null,
+  messages: [],
+  draggedTag: null,
+};
+
+let toastTimer = null;
+let suppressDialogResetClose = false;
+let toastActionHandler = null;
+let undoState = null;
+let applyDropDepth = 0;
+let removeDropDepth = 0;
+
+const API = {
+  async fetchJSON(url, options = {}) {
+    const response = await fetch(url, options);
+    const isJson = response.headers.get('content-type')?.includes('application/json');
+    if (!response.ok) {
+      let message = `Erreur ${response.status}`;
+      if (isJson) {
+        try {
+          const payload = await response.json();
+          if (payload?.error) {
+            message = payload.error;
+          }
+        } catch (_) {
+          // ignore parse failure
+        }
+      }
+      throw new Error(message);
+    }
+    if (!isJson || response.status === 204) {
+      return null;
+    }
+    return response.json();
+  },
+  listTags() {
+    return this.fetchJSON('/api/tags');
+  },
+  createTag(payload) {
+    return this.fetchJSON('/api/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  },
+  listInvoices(filters) {
+    const params = new URLSearchParams({
+      search: filters.search || '',
+      status: filters.status || 'all',
+      tag: filters.tag || 'all',
+      period: filters.period || 'all',
+    });
+    return this.fetchJSON(`/api/invoices?${params.toString()}`);
+  },
+  getInvoice(id) {
+    return this.fetchJSON(`/api/invoices/${id}`);
+  },
+  updateInvoice(id, payload) {
+    return this.fetchJSON(`/api/invoices/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  },
+  addTag(invoiceId, tagId) {
+    return this.fetchJSON(`/api/invoices/${invoiceId}/tags`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId, appliedByUserId: CURRENT_USER_ID }),
+    });
+  },
+  removeTag(invoiceId, tagId) {
+    return this.fetchJSON(`/api/invoices/${invoiceId}/tags/${tagId}`, {
+      method: 'DELETE',
+    });
+  },
+  listMessages(invoiceId) {
+    return this.fetchJSON(`/api/invoices/${invoiceId}/messages`);
+  },
+  createMessage(invoiceId, body) {
+    return this.fetchJSON(`/api/invoices/${invoiceId}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body, fromUserId: CURRENT_USER_ID }),
+    });
+  },
+  createInvoice(payload) {
+    return this.fetchJSON('/api/invoices', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  },
+};
+
+init().catch((error) => {
+  console.error(error);
+  showToast("Impossible de démarrer l'application", { type: 'error' });
+});
+
+async function init() {
+  attachEventListeners();
+  setupDragAndDrop();
+  await Promise.all([loadTags(), loadInvoices({ initial: true })]);
+}
+
+function attachEventListeners() {
+  DOM.searchInput.addEventListener('input', debounce(() => {
+    state.filters.search = DOM.searchInput.value.trim();
+    loadInvoices();
+  }, 200));
+
+  DOM.statusFilter.addEventListener('change', () => {
+    state.filters.status = DOM.statusFilter.value;
+    loadInvoices();
+  });
+
+  DOM.tagFilter.addEventListener('change', () => {
+    state.filters.tag = DOM.tagFilter.value;
+    loadInvoices();
+  });
+
+  DOM.periodFilter.addEventListener('change', () => {
+    state.filters.period = DOM.periodFilter.value;
+    loadInvoices();
+  });
+
+  DOM.chatForm.addEventListener('submit', handleChatSubmit);
+
+  DOM.openUploadDialog.addEventListener('click', () => {
+    if (typeof DOM.uploadDialog?.showModal !== 'function') {
+      showToast('Votre navigateur ne supporte pas la fenêtre de dialogue.', { type: 'error' });
+      return;
+    }
+    suppressDialogResetClose = true;
+    DOM.uploadForm.reset();
+    suppressDialogResetClose = false;
+    DOM.uploadDialog.showModal();
+    const firstField = DOM.uploadForm.querySelector('input, select, textarea');
+    firstField?.focus();
+  });
+
+  DOM.uploadForm.addEventListener('reset', (event) => {
+    if (suppressDialogResetClose) {
+      return;
+    }
+    if (event.isTrusted && DOM.uploadDialog.open) {
+      DOM.uploadDialog.close();
+    }
+  });
+
+  DOM.uploadForm.addEventListener('submit', handleUploadSubmit);
+
+  DOM.toggleTagForm.addEventListener('click', () => {
+    const willShow = DOM.tagForm.hasAttribute('hidden');
+    DOM.tagForm.toggleAttribute('hidden', !willShow);
+    if (willShow) {
+      DOM.tagForm.reset();
+      DOM.tagForm.querySelector('input')?.focus();
+    }
+  });
+
+  DOM.cancelTagForm.addEventListener('click', () => {
+    DOM.tagForm.reset();
+    DOM.tagForm.setAttribute('hidden', '');
+  });
+
+  DOM.tagForm.addEventListener('submit', handleTagSubmit);
+}
+
+function setupDragAndDrop() {
+  if (DOM.preview) {
+    DOM.preview.addEventListener('dragenter', handleApplyDragEnter);
+    DOM.preview.addEventListener('dragover', handleApplyDragOver);
+    DOM.preview.addEventListener('dragleave', handleApplyDragLeave);
+    DOM.preview.addEventListener('drop', handleApplyDrop);
+  }
+
+  if (DOM.removeTagDropzone) {
+    DOM.removeTagDropzone.addEventListener('dragenter', handleRemoveDragEnter);
+    DOM.removeTagDropzone.addEventListener('dragover', handleRemoveDragOver);
+    DOM.removeTagDropzone.addEventListener('dragleave', handleRemoveDragLeave);
+    DOM.removeTagDropzone.addEventListener('drop', handleRemoveDrop);
+  }
+}
+
+function registerDraggable(element, data) {
+  if (!element) return;
+  element.draggable = true;
+  element.dataset.tagId = data.tagId;
+  element.addEventListener('dragstart', (event) => handleTagDragStart(event, data));
+  element.addEventListener('dragend', handleTagDragEnd);
+}
+
+function handleTagDragStart(event, data) {
+  if (!event.dataTransfer) return;
+  state.draggedTag = data;
+  applyDropDepth = 0;
+  removeDropDepth = 0;
+  setPreviewDropState(false);
+  setRemoveDropState(false);
+  event.dataTransfer.effectAllowed = data.source === 'applied' ? 'move' : 'copy';
+  try {
+    event.dataTransfer.setData('application/x-inbox-tag', JSON.stringify(data));
+  } catch (_) {
+    // ignore custom mime type error
+  }
+  event.dataTransfer.setData('text/plain', data.tagId);
+}
+
+function handleTagDragEnd() {
+  state.draggedTag = null;
+  applyDropDepth = 0;
+  removeDropDepth = 0;
+  setPreviewDropState(false);
+  setRemoveDropState(false);
+}
+
+function extractTagDragData(event) {
+  const dt = event.dataTransfer;
+  if (dt) {
+    try {
+      const payload = dt.getData('application/x-inbox-tag');
+      if (payload) {
+        return JSON.parse(payload);
+      }
+    } catch (_) {
+      // ignore
+    }
+    const text = dt.getData('text/plain');
+    if (text) {
+      return { tagId: text, source: state.draggedTag?.source || 'unknown' };
+    }
+  }
+  return state.draggedTag;
+}
+
+function canDropTagOnPreview(data) {
+  if (!data || !data.tagId || !state.selectedInvoice) {
+    return false;
+  }
+  return !state.selectedInvoice.tags?.some((link) => link.tagId === data.tagId);
+}
+
+function setPreviewDropState(active) {
+  if (!DOM.preview) return;
+  DOM.preview.dataset.dropActive = active ? 'true' : 'false';
+}
+
+function handleApplyDragEnter(event) {
+  const data = extractTagDragData(event);
+  if (!canDropTagOnPreview(data)) return;
+  applyDropDepth += 1;
+  setPreviewDropState(true);
+  event.preventDefault();
+}
+
+function handleApplyDragOver(event) {
+  const data = extractTagDragData(event);
+  if (!canDropTagOnPreview(data)) {
+    setPreviewDropState(false);
+    return;
+  }
+  event.preventDefault();
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = 'copy';
+  }
+  setPreviewDropState(true);
+}
+
+function handleApplyDragLeave(event) {
+  const data = extractTagDragData(event);
+  if (!canDropTagOnPreview(data)) {
+    return;
+  }
+  applyDropDepth = Math.max(0, applyDropDepth - 1);
+  if (applyDropDepth === 0) {
+    setPreviewDropState(false);
+  }
+}
+
+function handleApplyDrop(event) {
+  const data = extractTagDragData(event);
+  if (!canDropTagOnPreview(data)) {
+    setPreviewDropState(false);
+    return;
+  }
+  event.preventDefault();
+  applyDropDepth = 0;
+  setPreviewDropState(false);
+  applyTag(data.tagId);
+}
+
+function canDropTagOnRemove(data) {
+  if (!data || !data.tagId || !state.selectedInvoice) {
+    return false;
+  }
+  return state.selectedInvoice.tags?.some((link) => link.tagId === data.tagId);
+}
+
+function setRemoveDropState(active) {
+  if (!DOM.removeTagDropzone) return;
+  if (DOM.removeTagDropzone.getAttribute('aria-disabled') === 'true') {
+    DOM.removeTagDropzone.dataset.active = 'false';
+    return;
+  }
+  DOM.removeTagDropzone.dataset.active = active ? 'true' : 'false';
+}
+
+function setRemoveDropzoneEnabled(enabled) {
+  if (!DOM.removeTagDropzone) return;
+  if (enabled) {
+    DOM.removeTagDropzone.removeAttribute('aria-disabled');
+    DOM.removeTagDropzone.dataset.active = 'false';
+  } else {
+    DOM.removeTagDropzone.setAttribute('aria-disabled', 'true');
+    DOM.removeTagDropzone.dataset.active = 'false';
+  }
+}
+
+function handleRemoveDragEnter(event) {
+  const data = extractTagDragData(event);
+  if (!canDropTagOnRemove(data)) return;
+  removeDropDepth += 1;
+  setRemoveDropState(true);
+  event.preventDefault();
+}
+
+function handleRemoveDragOver(event) {
+  const data = extractTagDragData(event);
+  if (!canDropTagOnRemove(data)) {
+    setRemoveDropState(false);
+    return;
+  }
+  event.preventDefault();
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = 'move';
+  }
+  setRemoveDropState(true);
+}
+
+function handleRemoveDragLeave(event) {
+  const data = extractTagDragData(event);
+  if (!canDropTagOnRemove(data)) {
+    return;
+  }
+  removeDropDepth = Math.max(0, removeDropDepth - 1);
+  if (removeDropDepth === 0) {
+    setRemoveDropState(false);
+  }
+}
+
+function handleRemoveDrop(event) {
+  const data = extractTagDragData(event);
+  if (!canDropTagOnRemove(data)) {
+    setRemoveDropState(false);
+    return;
+  }
+  event.preventDefault();
+  removeDropDepth = 0;
+  setRemoveDropState(false);
+  removeTag(data.tagId);
+}
+
+async function loadTags() {
+  try {
+    const tags = await API.listTags();
+    state.tags = tags;
+    renderTagSidebar();
+    populateTagFilter();
+    renderTagPicker(state.selectedInvoice);
+  } catch (error) {
+    console.error(error);
+    showToast('Impossible de charger les tags', { type: 'error' });
+  }
+}
+
+async function loadInvoices({ initial = false } = {}) {
+  try {
+    const invoices = await API.listInvoices(state.filters);
+    state.invoices = invoices;
+    renderInvoiceList();
+
+    if (!invoices.length) {
+      showDetail(null);
+      return;
+    }
+
+    if (initial && invoices[0]) {
+      await selectInvoice(invoices[0].id);
+      return;
+    }
+
+    if (state.selectedInvoiceId) {
+      const exists = invoices.some((invoice) => invoice.id === state.selectedInvoiceId);
+      if (!exists) {
+        await selectInvoice(invoices[0].id);
+        return;
+      }
+      if (state.selectedInvoice) {
+        renderInvoiceList();
+      }
+      return;
+    }
+
+    if (invoices[0]) {
+      await selectInvoice(invoices[0].id);
+    }
+  } catch (error) {
+    console.error(error);
+    showToast('Erreur lors du chargement des factures', { type: 'error' });
+  }
+}
+
+function renderInvoiceList() {
+  DOM.invoiceList.innerHTML = '';
+  if (!state.invoices.length) {
+    DOM.emptyState.hidden = false;
+    return;
+  }
+  DOM.emptyState.hidden = true;
+
+  const fragment = document.createDocumentFragment();
+  for (const invoice of state.invoices) {
+    const node = DOM.invoiceTemplate.content.firstElementChild.cloneNode(true);
+    const button = node.querySelector('.invoice-item__button');
+    button.dataset.id = invoice.id;
+    button.addEventListener('click', () => selectInvoice(invoice.id));
+    if (invoice.id === state.selectedInvoiceId) {
+      button.classList.add('is-selected');
+    }
+    node.querySelector('.invoice-item__vendor').textContent = invoice.vendor || 'Sans fournisseur';
+    node.querySelector('.invoice-item__amount').textContent = formatCurrency(invoice.amountTotal);
+    node.querySelector('.invoice-item__date').textContent = formatDate(invoice.invoiceDate || invoice.createdAt);
+    node.querySelector('.invoice-item__status').textContent = invoice.statusLabel || '';
+    fragment.appendChild(node);
+  }
+  DOM.invoiceList.appendChild(fragment);
+}
+
+function renderTagSidebar() {
+  DOM.tagList.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+  for (const tag of state.tags) {
+    const node = DOM.tagTemplate.content.firstElementChild.cloneNode(true);
+    node.querySelector('.tag-list__color').style.background = tag.color || '#5b5bd6';
+    node.querySelector('.tag-list__label').textContent = tag.label;
+    node.querySelector('.tag-list__count').textContent = tag.usageCount?.toString() || '0';
+    node.tabIndex = 0;
+    node.setAttribute('role', 'button');
+    node.setAttribute('aria-label', `Appliquer le tag ${tag.label}`);
+    node.addEventListener('click', () => applyTag(tag.id));
+    node.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        applyTag(tag.id);
+      }
+    });
+    registerDraggable(node, { tagId: tag.id, source: 'available' });
+    fragment.appendChild(node);
+  }
+  DOM.tagList.appendChild(fragment);
+}
+
+function populateTagFilter() {
+  const current = state.filters.tag;
+  DOM.tagFilter.innerHTML = '';
+  const optionAll = document.createElement('option');
+  optionAll.value = 'all';
+  optionAll.textContent = 'Tous';
+  DOM.tagFilter.appendChild(optionAll);
+  for (const tag of state.tags) {
+    const option = document.createElement('option');
+    option.value = tag.id;
+    option.textContent = tag.label;
+    DOM.tagFilter.appendChild(option);
+  }
+  DOM.tagFilter.value = current;
+}
+
+async function selectInvoice(id) {
+  if (!id) {
+    showDetail(null);
+    return;
+  }
+  try {
+    const [invoice, messages] = await Promise.all([API.getInvoice(id), API.listMessages(id)]);
+    state.selectedInvoiceId = id;
+    state.selectedInvoice = invoice;
+    state.messages = messages;
+    const listIndex = state.invoices.findIndex((item) => item.id === id);
+    if (listIndex !== -1) {
+      state.invoices[listIndex] = invoice;
+    }
+    renderInvoiceList();
+    showDetail(invoice);
+    renderChat();
+  } catch (error) {
+    console.error(error);
+    showToast('Impossible de charger la facture sélectionnée', { type: 'error' });
+  }
+}
+
+function showDetail(invoice) {
+  setPreviewDropState(false);
+  setRemoveDropState(false);
+  applyDropDepth = 0;
+  removeDropDepth = 0;
+  if (!invoice) {
+    state.selectedInvoiceId = null;
+    state.selectedInvoice = null;
+    state.messages = [];
+    DOM.detailContent.hidden = true;
+    DOM.detailEmpty.hidden = false;
+    DOM.chatForm.setAttribute('hidden', '');
+    DOM.chatInput.value = '';
+    DOM.chatInput.disabled = true;
+    setRemoveDropzoneEnabled(false);
+    clearUndoState();
+    return;
+  }
+  if (undoState && undoState.invoiceId !== invoice.id) {
+    clearUndoState({ keepToast: true });
+  }
+  DOM.detailEmpty.hidden = true;
+  DOM.detailContent.hidden = false;
+
+  DOM.detailVendor.textContent = invoice.vendor || 'Sans fournisseur';
+  const summaryParts = [];
+  if (invoice.amountTotal !== undefined && invoice.amountTotal !== null) {
+    summaryParts.push(formatCurrency(invoice.amountTotal));
+  }
+  if (invoice.invoiceDate) {
+    summaryParts.push(formatDate(invoice.invoiceDate));
+  }
+  DOM.detailSummary.textContent = summaryParts.join(' • ');
+
+  populateStatusSelect(invoice.status);
+  renderPreview(invoice.previewUrl);
+  renderAppliedTags(invoice);
+  renderTagPicker(invoice);
+  renderOcr(invoice.ocrFields || []);
+
+  if (invoice.sender) {
+    DOM.chatPartner.textContent = `Échanges avec ${invoice.sender.name}`;
+  } else {
+    DOM.chatPartner.textContent = "Chat interne";
+  }
+  DOM.chatForm.removeAttribute('hidden');
+  DOM.chatInput.disabled = false;
+  DOM.chatInput.value = '';
+}
+
+function populateStatusSelect(current) {
+  DOM.statusSelect.innerHTML = '';
+  for (const option of STATUS_OPTIONS) {
+    const node = document.createElement('option');
+    node.value = option.value;
+    node.textContent = option.label;
+    DOM.statusSelect.appendChild(node);
+  }
+  DOM.statusSelect.value = current || 'nouvelle';
+  DOM.statusSelect.onchange = async (event) => {
+    if (!state.selectedInvoice) return;
+    const newStatus = event.target.value;
+    try {
+      const updated = await API.updateInvoice(state.selectedInvoice.id, { status: newStatus });
+      state.selectedInvoice = updated;
+      mergeInvoice(updated);
+      showToast('Statut mis à jour');
+    } catch (error) {
+      console.error(error);
+      showToast('Impossible de mettre à jour le statut', { type: 'error' });
+      DOM.statusSelect.value = state.selectedInvoice.status;
+    }
+  };
+}
+
+function renderPreview(previewUrl) {
+  DOM.preview.innerHTML = '';
+  if (previewUrl) {
+    const img = document.createElement('img');
+    img.src = previewUrl;
+    img.alt = 'Aperçu de la facture';
+    DOM.preview.appendChild(img);
+  } else {
+    const fallback = document.createElement('p');
+    fallback.textContent = "Aucun aperçu disponible";
+    DOM.preview.appendChild(fallback);
+  }
+}
+
+function renderAppliedTags(invoice) {
+  DOM.appliedTags.innerHTML = '';
+  if (!invoice.tags?.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Aucun tag appliqué pour le moment.';
+    empty.className = 'detail__hint';
+    DOM.appliedTags.appendChild(empty);
+    setRemoveDropzoneEnabled(false);
+    return;
+  }
+  setRemoveDropzoneEnabled(true);
+  for (const tag of invoice.tags) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'tag-chip';
+    button.dataset.active = 'true';
+    button.style.borderColor = `${tag.color || '#5b5bd6'}33`;
+    button.style.background = `${tag.color || '#5b5bd6'}26`;
+    button.textContent = tag.label;
+    button.title = 'Retirer ce tag';
+    button.setAttribute('aria-label', `Retirer le tag ${tag.label}`);
+    button.addEventListener('click', () => removeTag(tag.tagId));
+    registerDraggable(button, { tagId: tag.tagId, source: 'applied' });
+    DOM.appliedTags.appendChild(button);
+  }
+}
+
+function renderTagPicker(invoice) {
+  DOM.tagPicker.innerHTML = '';
+  if (!invoice) {
+    return;
+  }
+  const appliedIds = new Set(invoice.tags?.map((tag) => tag.tagId));
+  const available = state.tags.filter((tag) => !appliedIds.has(tag.id));
+  if (!available.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Tous les tags sont appliqués.';
+    empty.className = 'detail__hint';
+    DOM.tagPicker.appendChild(empty);
+    return;
+  }
+  for (const tag of available) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'tag-chip';
+    button.style.borderColor = `${tag.color || '#5b5bd6'}33`;
+    button.textContent = `Ajouter ${tag.label}`;
+    button.addEventListener('click', () => applyTag(tag.id));
+    registerDraggable(button, { tagId: tag.id, source: 'available' });
+    DOM.tagPicker.appendChild(button);
+  }
+}
+
+function renderOcr(fields) {
+  DOM.ocrList.innerHTML = '';
+  if (!fields.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Aucun champ OCR disponible.';
+    empty.className = 'detail__hint';
+    DOM.ocrList.appendChild(empty);
+    return;
+  }
+  for (const field of fields) {
+    const item = document.createElement('li');
+    item.className = 'ocr-item';
+    const label = document.createElement('div');
+    label.className = 'ocr-item__label';
+    label.textContent = field.label || field.id;
+    const value = document.createElement('div');
+    value.className = 'ocr-item__value';
+    value.textContent = field.value || '—';
+    const confidence = document.createElement('div');
+    confidence.className = 'ocr-item__confidence';
+    if (typeof field.confidence === 'number') {
+      confidence.textContent = `Confiance ${(field.confidence * 100).toFixed(0)}%`;
+    } else {
+      confidence.textContent = 'Confiance inconnue';
+    }
+    item.append(label, value, confidence);
+    DOM.ocrList.appendChild(item);
+  }
+}
+
+function renderChat() {
+  DOM.chatList.innerHTML = '';
+  if (!state.messages.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Aucun message pour le moment.';
+    empty.className = 'detail__hint';
+    DOM.chatList.appendChild(empty);
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  for (const message of state.messages) {
+    const item = document.createElement('li');
+    const bubble = document.createElement('div');
+    bubble.className = 'chat-bubble';
+    bubble.dataset.role = message.authorRole || 'tagger';
+    const text = document.createElement('p');
+    text.textContent = message.body;
+    const meta = document.createElement('span');
+    meta.className = 'chat-bubble__meta';
+    const author = message.authorName || 'Utilisateur';
+    meta.textContent = `${author} • ${formatDateTime(message.createdAt)}`;
+    bubble.append(text, meta);
+    item.appendChild(bubble);
+    fragment.appendChild(item);
+  }
+  DOM.chatList.appendChild(fragment);
+}
+
+async function applyTag(tagId) {
+  if (!state.selectedInvoice) return;
+  if (state.selectedInvoice.tags?.some((tag) => tag.tagId === tagId)) {
+    return;
+  }
+  try {
+    const invoiceId = state.selectedInvoice.id;
+    const label = resolveTagLabel(tagId);
+    const updated = await API.addTag(invoiceId, tagId);
+    state.selectedInvoice = updated;
+    mergeInvoice(updated);
+    await loadTags();
+    undoState = { kind: 'add', invoiceId, tagId, label };
+    showToast(`Tag « ${label} » ajouté`, {
+      actionLabel: 'Annuler',
+      duration: 8000,
+      onAction: handleUndo,
+    });
+  } catch (error) {
+    console.error(error);
+    showToast('Impossible d\'ajouter le tag', { type: 'error' });
+  }
+}
+
+async function removeTag(tagId) {
+  if (!state.selectedInvoice) return;
+  try {
+    const invoiceId = state.selectedInvoice.id;
+    const label = resolveTagLabel(tagId);
+    const result = await API.removeTag(invoiceId, tagId);
+    const updated = result?.invoice || state.selectedInvoice;
+    state.selectedInvoice = updated;
+    mergeInvoice(updated);
+    await loadTags();
+    undoState = { kind: 'remove', invoiceId, tagId, label };
+    showToast(`Tag « ${label} » retiré`, {
+      actionLabel: 'Annuler',
+      duration: 8000,
+      onAction: handleUndo,
+    });
+  } catch (error) {
+    console.error(error);
+    showToast('Impossible de retirer le tag', { type: 'error' });
+  }
+}
+
+async function handleChatSubmit(event) {
+  event.preventDefault();
+  if (!state.selectedInvoice) return;
+  const message = DOM.chatInput.value.trim();
+  if (!message) return;
+  DOM.chatInput.disabled = true;
+  try {
+    const created = await API.createMessage(state.selectedInvoice.id, message);
+    state.messages.push(created);
+    renderChat();
+    DOM.chatInput.value = '';
+    showToast('Message envoyé');
+  } catch (error) {
+    console.error(error);
+    showToast("Impossible d'envoyer le message", { type: 'error' });
+  } finally {
+    DOM.chatInput.disabled = false;
+    DOM.chatInput.focus();
+  }
+}
+
+async function handleUploadSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(DOM.uploadForm);
+  const payload = {
+    vendor: formData.get('vendor')?.toString().trim() || '',
+    amountTotal: parseFloat(formData.get('amountTotal')) || 0,
+    invoiceDate: formData.get('invoiceDate') || null,
+    source: formData.get('source') || 'upload',
+    paymentMethod: formData.get('paymentMethod')?.toString().trim() || '',
+    previewUrl: formData.get('previewUrl')?.toString().trim() || '',
+    notes: formData.get('notes')?.toString().trim() || '',
+    senderUserId: formData.get('senderUserId') || null,
+  };
+
+  if (!payload.vendor) {
+    showToast('Le fournisseur est requis', { type: 'error' });
+    return;
+  }
+
+  try {
+    const invoice = await API.createInvoice(payload);
+    DOM.uploadDialog.close();
+    showToast('Facture créée');
+    await loadInvoices();
+    if (invoice?.id) {
+      await selectInvoice(invoice.id);
+    }
+  } catch (error) {
+    console.error(error);
+    showToast('Impossible de créer la facture', { type: 'error' });
+  }
+}
+
+async function handleTagSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(DOM.tagForm);
+  const label = formData.get('label')?.toString().trim();
+  if (!label) {
+    showToast('Le nom du tag est requis', { type: 'error' });
+    return;
+  }
+  const color = formData.get('color')?.toString() || '#5b5bd6';
+  try {
+    const created = await API.createTag({ label, color });
+    state.tags.push({ ...created, usageCount: 0 });
+    renderTagSidebar();
+    populateTagFilter();
+    renderTagPicker(state.selectedInvoice);
+    DOM.tagForm.reset();
+    DOM.tagForm.setAttribute('hidden', '');
+    showToast('Tag créé');
+  } catch (error) {
+    console.error(error);
+    showToast("Impossible de créer le tag", { type: 'error' });
+  }
+}
+
+function mergeInvoice(updated) {
+  const index = state.invoices.findIndex((invoice) => invoice.id === updated.id);
+  if (index !== -1) {
+    state.invoices[index] = updated;
+  }
+  if (state.selectedInvoice?.id === updated.id) {
+    state.selectedInvoice = updated;
+    showDetail(updated);
+  }
+  renderInvoiceList();
+}
+
+function showToast(message, { type, actionLabel, onAction, duration = 2800 } = {}) {
+  if (!DOM.toast || !DOM.toastMessage || !DOM.toastAction) return;
+  DOM.toastMessage.textContent = message;
+  DOM.toast.dataset.visible = 'true';
+  DOM.toast.style.background =
+    type === 'error' ? 'rgba(248, 113, 113, 0.9)' : 'rgba(17, 24, 39, 0.9)';
+  disableToastAction();
+  if (actionLabel && typeof onAction === 'function') {
+    DOM.toastAction.textContent = actionLabel;
+    DOM.toastAction.dataset.visible = 'true';
+    DOM.toastAction.setAttribute('aria-hidden', 'false');
+    toastActionHandler = (event) => {
+      event.preventDefault();
+      onAction();
+    };
+    DOM.toastAction.addEventListener('click', toastActionHandler);
+  } else {
+    DOM.toastAction.dataset.visible = 'false';
+    DOM.toastAction.setAttribute('aria-hidden', 'true');
+  }
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => {
+    hideToast();
+  }, duration);
+}
+
+function hideToast() {
+  if (!DOM.toast) return;
+  DOM.toast.dataset.visible = 'false';
+  clearTimeout(toastTimer);
+  toastTimer = null;
+  disableToastAction();
+}
+
+function disableToastAction() {
+  if (!DOM.toastAction) return;
+  if (toastActionHandler) {
+    DOM.toastAction.removeEventListener('click', toastActionHandler);
+    toastActionHandler = null;
+  }
+  DOM.toastAction.dataset.visible = 'false';
+  DOM.toastAction.setAttribute('aria-hidden', 'true');
+  DOM.toastAction.textContent = '';
+  DOM.toastAction.blur();
+}
+
+function clearUndoState({ keepToast = false } = {}) {
+  undoState = null;
+  disableToastAction();
+  if (!keepToast) {
+    hideToast();
+  }
+}
+
+async function handleUndo() {
+  if (!undoState) return;
+  const action = undoState;
+  undoState = null;
+  hideToast();
+  try {
+    if (action.kind === 'add') {
+      const result = await API.removeTag(action.invoiceId, action.tagId);
+      const updated = result?.invoice || state.selectedInvoice;
+      if (updated) {
+        state.selectedInvoice = updated;
+        mergeInvoice(updated);
+      }
+      await loadTags();
+      showToast(`Ajout du tag « ${action.label} » annulé`);
+    } else if (action.kind === 'remove') {
+      const updated = await API.addTag(action.invoiceId, action.tagId);
+      if (updated) {
+        state.selectedInvoice = updated;
+        mergeInvoice(updated);
+      }
+      await loadTags();
+      showToast(`Suppression du tag « ${action.label} » annulée`);
+    }
+  } catch (error) {
+    console.error(error);
+    showToast("Impossible d'annuler l'action", { type: 'error' });
+  }
+}
+
+function resolveTagLabel(tagId) {
+  if (!tagId) return 'Tag';
+  const inState = state.tags.find((tag) => tag.id === tagId);
+  if (inState?.label) {
+    return inState.label;
+  }
+  const inInvoice = state.selectedInvoice?.tags?.find((tag) => tag.tagId === tagId);
+  if (inInvoice?.label) {
+    return inInvoice.label;
+  }
+  return 'Tag';
+}
+
+function formatCurrency(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '—';
+  }
+  return new Intl.NumberFormat('fr-CA', { style: 'currency', currency: 'CAD' }).format(value);
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return new Intl.DateTimeFormat('fr-CA', { dateStyle: 'medium' }).format(date);
+}
+
+function formatDateTime(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat('fr-CA', { dateStyle: 'short', timeStyle: 'short' }).format(date);
+}
+
+function debounce(fn, delay) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+}

--- a/public/src/styles.css
+++ b/public/src/styles.css
@@ -1,0 +1,631 @@
+:root {
+  color-scheme: dark;
+  --bg: #0e111a;
+  --bg-elevated: #171c2a;
+  --bg-panel: #1f2535;
+  --bg-muted: #242b3d;
+  --border: rgba(255, 255, 255, 0.08);
+  --accent: #5b5bd6;
+  --accent-soft: rgba(91, 91, 214, 0.2);
+  --text-primary: #f7f8fc;
+  --text-secondary: #b3bad9;
+  --danger: #f87171;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, rgba(91, 91, 214, 0.1), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(99, 179, 237, 0.08), transparent 55%),
+    var(--bg);
+  color: var(--text-primary);
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.75rem clamp(1.5rem, 3vw, 3.5rem);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 2.2vw, 2.4rem);
+}
+
+.app-header p {
+  margin: 0.25rem 0 0;
+  color: var(--text-secondary);
+  max-width: 32rem;
+}
+
+.app-header__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.app-grid {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) 360px;
+  gap: 1.75rem;
+  padding: 0 clamp(1.5rem, 3vw, 3.5rem) 2rem;
+}
+
+.sidebar,
+.workspace,
+.detail {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  min-height: 70vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.sidebar h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.tag-form {
+  background: var(--bg-panel);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.tag-form input,
+.tag-form select,
+.filters input,
+.filters select,
+.chat-form input,
+.modal input,
+.modal select,
+.modal textarea {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: inherit;
+  font: inherit;
+}
+
+.tag-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.tag-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+  overflow-y: auto;
+}
+
+.tag-list__item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.75rem;
+  background: var(--bg-panel);
+}
+
+.tag-list__item[draggable='true'] {
+  cursor: grab;
+}
+
+.tag-list__item[draggable='true']:active {
+  cursor: grabbing;
+}
+
+.tag-list__color {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+}
+
+.tag-list__label {
+  font-weight: 500;
+}
+
+.tag-list__count {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.workspace {
+  gap: 1.25rem;
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.filters__field {
+  display: grid;
+  gap: 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.invoice-list {
+  background: var(--bg-panel);
+  border-radius: 1rem;
+  padding: 1rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.invoice-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+}
+
+.invoice-item__button {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.invoice-item__button:hover,
+.invoice-item__button:focus-visible {
+  background: rgba(91, 91, 214, 0.16);
+  outline: none;
+}
+
+.invoice-item__button.is-selected {
+  background: var(--accent-soft);
+  border: 1px solid rgba(91, 91, 214, 0.4);
+}
+
+.invoice-item__primary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.invoice-item__vendor {
+  font-weight: 600;
+}
+
+.invoice-item__amount {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.invoice-item__meta {
+  display: grid;
+  justify-items: end;
+  gap: 0.35rem;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.empty {
+  margin-top: 1.5rem;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.detail {
+  position: relative;
+  overflow: hidden;
+}
+
+.detail-empty {
+  margin: auto;
+  text-align: center;
+  color: var(--text-secondary);
+  max-width: 18rem;
+}
+
+.detail-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  height: 100%;
+}
+
+.detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.detail__header h2 {
+  margin: 0;
+}
+
+.detail__header p {
+  margin: 0.35rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.status label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.35rem;
+}
+
+.preview {
+  position: relative;
+  background: var(--bg-panel);
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  min-height: 180px;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  color: var(--text-secondary);
+  text-align: center;
+  overflow: hidden;
+}
+
+.preview::after {
+  content: 'Déposez le tag pour l\'appliquer';
+  position: absolute;
+  inset: 0.75rem;
+  display: grid;
+  place-items: center;
+  border-radius: 0.85rem;
+  border: 2px dashed rgba(91, 91, 214, 0.55);
+  background: rgba(91, 91, 214, 0.1);
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 140ms ease;
+}
+
+.preview[data-drop-active="true"]::after {
+  opacity: 1;
+}
+
+.preview img {
+  max-width: 100%;
+  border-radius: 0.75rem;
+}
+
+.detail__section h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.tag-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.detail__hint {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.tag-drop-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.75rem 0 1rem;
+}
+
+.tag-drop-actions__hint {
+  flex: 1 1 220px;
+}
+
+.dropzone {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px dashed var(--border);
+  border-radius: 999px;
+  padding: 0.45rem 1rem;
+  background: var(--bg-panel);
+  color: var(--text-secondary);
+  cursor: grab;
+  font-size: 0.85rem;
+  transition: border-color 140ms ease, background 140ms ease, color 140ms ease;
+}
+
+.dropzone span {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.dropzone:disabled,
+.dropzone[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.dropzone[data-active="true"] {
+  border-color: rgba(248, 113, 113, 0.9);
+  background: rgba(248, 113, 113, 0.18);
+  color: #fff;
+}
+
+.dropzone--remove {
+  border-color: rgba(248, 113, 113, 0.55);
+  color: rgba(248, 113, 113, 0.8);
+}
+
+.dropzone:focus-visible {
+  outline: 2px solid rgba(248, 113, 113, 0.6);
+  outline-offset: 2px;
+}
+
+.tag-chip {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--bg-panel);
+  cursor: pointer;
+  transition: transform 120ms ease, background 120ms ease;
+}
+
+.tag-chip[draggable='true'] {
+  cursor: grab;
+}
+
+.tag-chip[draggable='true']:active {
+  cursor: grabbing;
+}
+
+.tag-chip[data-active="true"] {
+  background: var(--accent-soft);
+  border-color: rgba(91, 91, 214, 0.55);
+}
+
+.tag-chip:hover,
+.tag-chip:focus-visible {
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.ocr-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.ocr-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: var(--bg-panel);
+}
+
+.ocr-item__label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.ocr-item__value {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.ocr-item__confidence {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.chat-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.chat-bubble {
+  padding: 0.75rem;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.chat-bubble[data-role="tagger"] {
+  border: 1px solid rgba(91, 91, 214, 0.4);
+}
+
+.chat-bubble__meta {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.chat-form {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.chat-form__field {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.primary-button,
+.ghost-button,
+.icon-button,
+.tag-chip {
+  font: inherit;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, var(--accent), #6e9cec);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  cursor: pointer;
+  font-weight: 600;
+  transition: filter 120ms ease;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  filter: brightness(1.1);
+  outline: none;
+}
+
+.ghost-button {
+  background: transparent;
+  color: inherit;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
+  cursor: pointer;
+}
+
+.icon-button {
+  border: 1px solid var(--border);
+  background: var(--bg-panel);
+  color: inherit;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.65rem;
+  cursor: pointer;
+}
+
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 2rem;
+  transform: translateX(-50%);
+  background: rgba(17, 24, 39, 0.9);
+  color: #fff;
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms ease;
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.toast[data-visible="true"] {
+  opacity: 1;
+}
+
+.toast__action {
+  border: none;
+  background: transparent;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  display: none;
+}
+
+.toast__action:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.toast__action[data-visible="true"] {
+  display: inline-flex;
+}
+
+.modal {
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: var(--bg-elevated);
+  color: inherit;
+  min-width: min(380px, 90vw);
+}
+
+.modal__intro {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.modal__field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+::backdrop {
+  background: rgba(8, 12, 24, 0.7);
+  backdrop-filter: blur(6px);
+}
+
+@media (max-width: 1100px) {
+  .app-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .detail {
+    order: 3;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,530 @@
+const http = require('http');
+const path = require('path');
+const { readFile, writeFile, stat } = require('fs/promises');
+const { randomUUID } = require('crypto');
+
+const PORT = process.env.PORT || 4173;
+const ORG_ID = 'org-demo';
+const DB_PATH = process.env.DB_PATH
+  ? path.resolve(process.env.DB_PATH)
+  : path.join(__dirname, 'data', 'db.json');
+const PUBLIC_DIR = path.join(__dirname, 'public');
+
+const STATUS_LABEL = {
+  nouvelle: 'Nouvelle',
+  a_verifier: 'À vérifier',
+  complete: 'Complète',
+  archive: 'Archivée',
+  ocr_error: 'Erreur OCR',
+};
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+  '.ttf': 'font/ttf',
+};
+
+const routes = [
+  { method: 'GET', pattern: /^\/api\/tags$/, handler: getTags },
+  { method: 'POST', pattern: /^\/api\/tags$/, handler: createTag },
+  { method: 'DELETE', pattern: /^\/api\/tags\/([^/]+)$/, handler: deleteTag },
+  { method: 'GET', pattern: /^\/api\/invoices$/, handler: listInvoices },
+  { method: 'POST', pattern: /^\/api\/invoices$/, handler: createInvoice },
+  { method: 'GET', pattern: /^\/api\/invoices\/([^/]+)$/, handler: getInvoice },
+  { method: 'PATCH', pattern: /^\/api\/invoices\/([^/]+)$/, handler: patchInvoice },
+  { method: 'POST', pattern: /^\/api\/invoices\/([^/]+)\/tags$/, handler: addInvoiceTag },
+  { method: 'DELETE', pattern: /^\/api\/invoices\/([^/]+)\/tags\/([^/]+)$/, handler: removeInvoiceTag },
+  { method: 'GET', pattern: /^\/api\/invoices\/([^/]+)\/messages$/, handler: listMessages },
+  { method: 'POST', pattern: /^\/api\/invoices\/([^/]+)\/messages$/, handler: createMessage },
+];
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.url.startsWith('/api/')) {
+      await handleApi(req, res);
+    } else {
+      await serveStatic(req, res);
+    }
+  } catch (error) {
+    console.error('Unexpected error', error);
+    sendJson(res, 500, { error: 'Erreur interne du serveur' });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Inbox server running on http://localhost:${PORT}`);
+});
+
+async function handleApi(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  for (const route of routes) {
+    if (req.method !== route.method) continue;
+    const match = url.pathname.match(route.pattern);
+    if (match) {
+      const params = match.slice(1);
+      await route.handler(req, res, params, url.searchParams);
+      return;
+    }
+  }
+  sendJson(res, 404, { error: 'Route inconnue' });
+}
+
+async function serveStatic(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  let pathname = decodeURIComponent(url.pathname);
+  if (pathname === '/') {
+    pathname = '/index.html';
+  }
+  const filePath = path.join(PUBLIC_DIR, pathname);
+  if (!filePath.startsWith(PUBLIC_DIR)) {
+    sendText(res, 403, 'Accès refusé');
+    return;
+  }
+
+  try {
+    const fileStat = await stat(filePath);
+    if (fileStat.isDirectory()) {
+      await serveFile(path.join(filePath, 'index.html'), res);
+    } else {
+      await serveFile(filePath, res);
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      // SPA fallback for routes without extension
+      if (!path.extname(pathname)) {
+        await serveFile(path.join(PUBLIC_DIR, 'index.html'), res);
+        return;
+      }
+      sendText(res, 404, 'Fichier introuvable');
+    } else {
+      console.error(error);
+      sendText(res, 500, 'Erreur de lecture de fichier');
+    }
+  }
+}
+
+async function serveFile(filePath, res) {
+  const data = await readFile(filePath);
+  const ext = path.extname(filePath);
+  const type = MIME_TYPES[ext] || 'application/octet-stream';
+  res.writeHead(200, { 'Content-Type': type });
+  res.end(data);
+}
+
+async function loadDb() {
+  const content = await readFile(DB_PATH, 'utf-8');
+  return JSON.parse(content);
+}
+
+async function saveDb(db) {
+  await writeFile(DB_PATH, JSON.stringify(db, null, 2), 'utf-8');
+}
+
+function buildMaps(db) {
+  const tagMap = new Map(db.tags.map((tag) => [tag.id, tag]));
+  const userMap = new Map(db.users.map((user) => [user.id, user]));
+  return { tagMap, userMap };
+}
+
+function decorateInvoice(invoice, db) {
+  const { tagMap, userMap } = buildMaps(db);
+  const sender = invoice.senderUserId ? userMap.get(invoice.senderUserId) : null;
+
+  return {
+    ...invoice,
+    statusLabel: STATUS_LABEL[invoice.status] || invoice.status,
+    sender: sender
+      ? {
+          id: sender.id,
+          name: sender.name,
+          email: sender.email,
+          phone: sender.phone,
+          role: sender.role,
+        }
+      : null,
+    tags: invoice.tags.map((link) => {
+      const tag = tagMap.get(link.tagId);
+      const user = userMap.get(link.appliedByUserId);
+      return {
+        tagId: link.tagId,
+        label: tag ? tag.label : 'Tag supprimé',
+        color: tag ? tag.color : '#777',
+        appliedByUserId: link.appliedByUserId,
+        appliedByName: user ? user.name : 'Inconnu',
+        createdAt: link.createdAt,
+      };
+    }),
+  };
+}
+
+function decorateMessage(message, db) {
+  const { userMap } = buildMaps(db);
+  const author = message.fromUserId ? userMap.get(message.fromUserId) : null;
+
+  return {
+    ...message,
+    authorName: author ? author.name : message.fromExternalPhone || 'Système',
+    authorRole: author ? author.role : 'external',
+  };
+}
+
+function computeTagUsage(db) {
+  const usage = Object.fromEntries(db.tags.map((tag) => [tag.id, 0]));
+  for (const invoice of db.invoices) {
+    for (const link of invoice.tags) {
+      if (usage[link.tagId] !== undefined) {
+        usage[link.tagId] += 1;
+      }
+    }
+  }
+  return usage;
+}
+
+function matchesFilters(invoice, db, { search, status, tag, period }) {
+  if (status && status !== 'all' && invoice.status !== status) {
+    return false;
+  }
+  if (tag && tag !== 'all' && !invoice.tags.some((link) => link.tagId === tag)) {
+    return false;
+  }
+  if (period && period !== 'all') {
+    const createdAt = new Date(invoice.createdAt);
+    const now = new Date();
+    const diffMs = now - createdAt;
+    const dayMs = 24 * 60 * 60 * 1000;
+    if (period === 'today' && createdAt.toDateString() !== now.toDateString()) {
+      return false;
+    }
+    if (period === '7d' && diffMs > 7 * dayMs) {
+      return false;
+    }
+    if (period === '30d' && diffMs > 30 * dayMs) {
+      return false;
+    }
+  }
+  if (search) {
+    const { tagMap, userMap } = buildMaps(db);
+    const invoiceText = [
+      invoice.vendor,
+      invoice.senderEmail,
+      invoice.senderPhone,
+      invoice.amountTotal ? invoice.amountTotal.toString() : '',
+      invoice.invoiceDate,
+      invoice.status,
+      ...invoice.tags.map((link) => {
+        const tagEntry = tagMap.get(link.tagId);
+        return tagEntry ? tagEntry.label : '';
+      }),
+      (() => {
+        const user = userMap.get(invoice.senderUserId);
+        return user ? user.name : '';
+      })(),
+    ]
+      .join(' ')
+      .toLowerCase();
+    if (!invoiceText.includes(search.toLowerCase())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function getTags(req, res) {
+  const db = await loadDb();
+  const usage = computeTagUsage(db);
+  const tags = db.tags
+    .filter((tag) => tag.orgId === ORG_ID)
+    .map((tag) => ({
+      ...tag,
+      usageCount: usage[tag.id] ?? 0,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+  sendJson(res, 200, tags);
+}
+
+async function createTag(req, res) {
+  const body = await readJsonBody(req, res);
+  if (!body) return;
+  const { label, color = '#4f46e5', createdByUserId = null } = body;
+  if (!label || typeof label !== 'string' || !label.trim()) {
+    sendJson(res, 400, { error: 'Label requis' });
+    return;
+  }
+  const normalized = label.trim();
+  const db = await loadDb();
+  const exists = db.tags.some(
+    (tag) => tag.orgId === ORG_ID && tag.label.toLowerCase() === normalized.toLowerCase(),
+  );
+  if (exists) {
+    sendJson(res, 409, { error: 'Ce tag existe déjà' });
+    return;
+  }
+  const tag = {
+    id: `tag-${randomUUID()}`,
+    orgId: ORG_ID,
+    label: normalized,
+    color,
+    isSystem: false,
+    createdAt: new Date().toISOString(),
+    createdByUserId,
+  };
+  db.tags.push(tag);
+  await saveDb(db);
+  sendJson(res, 201, tag);
+}
+
+async function deleteTag(req, res, params) {
+  const [id] = params;
+  const db = await loadDb();
+  const usage = computeTagUsage(db);
+  if ((usage[id] ?? 0) > 0) {
+    sendJson(res, 409, { error: 'Tag utilisé sur des factures' });
+    return;
+  }
+  const index = db.tags.findIndex((tag) => tag.id === id && tag.orgId === ORG_ID);
+  if (index === -1) {
+    sendJson(res, 404, { error: 'Tag introuvable' });
+    return;
+  }
+  const [removed] = db.tags.splice(index, 1);
+  await saveDb(db);
+  sendJson(res, 200, removed);
+}
+
+async function listInvoices(req, res, _params, searchParams) {
+  const search = searchParams.get('search') || '';
+  const status = searchParams.get('status') || 'all';
+  const tag = searchParams.get('tag') || 'all';
+  const period = searchParams.get('period') || 'all';
+
+  const db = await loadDb();
+  const invoices = db.invoices
+    .filter((invoice) => invoice.orgId === ORG_ID)
+    .filter((invoice) => matchesFilters(invoice, db, { search, status, tag, period }))
+    .map((invoice) => decorateInvoice(invoice, db))
+    .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+
+  sendJson(res, 200, invoices);
+}
+
+async function getInvoice(req, res, params) {
+  const [id] = params;
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === id && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+  sendJson(res, 200, decorateInvoice(invoice, db));
+}
+
+async function patchInvoice(req, res, params) {
+  const [id] = params;
+  const body = await readJsonBody(req, res);
+  if (!body) return;
+
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === id && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+
+  const allowed = new Set(['vendor', 'amountTotal', 'invoiceDate', 'status', 'paymentMethod', 'ocrFields']);
+  Object.entries(body).forEach(([key, value]) => {
+    if (allowed.has(key)) {
+      invoice[key] = value;
+    }
+  });
+  invoice.updatedAt = new Date().toISOString();
+  await saveDb(db);
+  sendJson(res, 200, decorateInvoice(invoice, db));
+}
+
+async function createInvoice(req, res) {
+  const body = await readJsonBody(req, res);
+  if (!body) return;
+  const {
+    vendor,
+    amountTotal,
+    invoiceDate,
+    senderUserId,
+    source = 'upload',
+    paymentMethod = '',
+    previewUrl = '',
+    notes = '',
+  } = body;
+
+  if (!vendor) {
+    sendJson(res, 400, { error: 'Fournisseur requis' });
+    return;
+  }
+
+  const db = await loadDb();
+  const invoice = {
+    id: `inv-${randomUUID()}`,
+    orgId: ORG_ID,
+    senderUserId: senderUserId || null,
+    source,
+    originalFilename: null,
+    driveFileId: null,
+    driveFileUrl: null,
+    previewUrl,
+    amountTotal: amountTotal !== undefined && amountTotal !== null ? Number(amountTotal) : null,
+    invoiceDate: invoiceDate || null,
+    vendor,
+    paymentMethod,
+    status: 'nouvelle',
+    notes,
+    tags: [],
+    ocrFields: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  db.invoices.push(invoice);
+  await saveDb(db);
+  sendJson(res, 201, decorateInvoice(invoice, db));
+}
+
+async function addInvoiceTag(req, res, params) {
+  const [invoiceId] = params;
+  const body = await readJsonBody(req, res);
+  if (!body) return;
+  const { tagId, appliedByUserId = null } = body;
+  if (!tagId) {
+    sendJson(res, 400, { error: 'tagId requis' });
+    return;
+  }
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === invoiceId && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+  const hasTag = invoice.tags.some((link) => link.tagId === tagId);
+  if (!hasTag) {
+    invoice.tags.push({
+      tagId,
+      appliedByUserId,
+      createdAt: new Date().toISOString(),
+    });
+    invoice.updatedAt = new Date().toISOString();
+    await saveDb(db);
+  }
+  sendJson(res, 200, decorateInvoice(invoice, db));
+}
+
+async function removeInvoiceTag(req, res, params) {
+  const [invoiceId, tagId] = params;
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === invoiceId && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+  const index = invoice.tags.findIndex((link) => link.tagId === tagId);
+  if (index === -1) {
+    sendJson(res, 404, { error: 'Tag non appliqué' });
+    return;
+  }
+  const [removed] = invoice.tags.splice(index, 1);
+  invoice.updatedAt = new Date().toISOString();
+  await saveDb(db);
+  sendJson(res, 200, { removed, invoice: decorateInvoice(invoice, db) });
+}
+
+async function listMessages(req, res, params) {
+  const [invoiceId] = params;
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === invoiceId && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+  const messages = db.messages
+    .filter((message) => message.invoiceId === invoiceId)
+    .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+    .map((message) => decorateMessage(message, db));
+  sendJson(res, 200, messages);
+}
+
+async function createMessage(req, res, params) {
+  const [invoiceId] = params;
+  const body = await readJsonBody(req, res);
+  if (!body) return;
+  const { body: messageBody, fromUserId = null, fromExternalPhone = null, attachments = [] } = body;
+  if (!messageBody || typeof messageBody !== 'string' || !messageBody.trim()) {
+    sendJson(res, 400, { error: 'Message vide' });
+    return;
+  }
+  const db = await loadDb();
+  const invoice = db.invoices.find((item) => item.id === invoiceId && item.orgId === ORG_ID);
+  if (!invoice) {
+    sendJson(res, 404, { error: 'Facture introuvable' });
+    return;
+  }
+  const message = {
+    id: `msg-${randomUUID()}`,
+    invoiceId,
+    fromUserId,
+    fromExternalPhone,
+    body: messageBody.trim(),
+    attachments,
+    sentVia: fromExternalPhone ? 'sms' : 'inapp',
+    deliveryStatus: 'sent',
+    createdAt: new Date().toISOString(),
+  };
+  db.messages.push(message);
+  invoice.updatedAt = new Date().toISOString();
+  await saveDb(db);
+  sendJson(res, 201, decorateMessage(message, db));
+}
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function sendText(res, statusCode, message) {
+  res.writeHead(statusCode, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end(message);
+}
+
+async function readJsonBody(req, res) {
+  try {
+    const raw = await readBody(req);
+    if (!raw) return {};
+    return JSON.parse(raw);
+  } catch (error) {
+    sendJson(res, 400, { error: 'JSON invalide' });
+    return null;
+  }
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req
+      .on('data', (chunk) => {
+        chunks.push(chunk);
+      })
+      .on('end', () => {
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      })
+      .on('error', reject);
+  });
+}

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,126 @@
+const assert = require('node:assert/strict');
+const { mkdtemp, copyFile, rm } = require('node:fs/promises');
+const { tmpdir } = require('node:os');
+const { join, resolve } = require('node:path');
+const { spawn } = require('node:child_process');
+
+const ROOT_DIR = resolve(__dirname, '..');
+const ORIGINAL_DB = join(ROOT_DIR, 'data', 'db.json');
+
+(async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'inbox-test-'));
+  const tempDb = join(tempDir, 'db.json');
+  await copyFile(ORIGINAL_DB, tempDb);
+
+  const port = 4100 + Math.floor(Math.random() * 500);
+  const server = spawn(process.execPath, ['server.js'], {
+    cwd: ROOT_DIR,
+    env: { ...process.env, PORT: String(port), DB_PATH: tempDb },
+    stdio: 'inherit',
+  });
+
+  try {
+    await waitForServer(port);
+    const client = createClient(port);
+
+    const tags = await client.get('/api/tags');
+    assert.ok(Array.isArray(tags) && tags.length > 0, 'tags should load');
+
+    const createdTag = await client.post('/api/tags', { label: 'Test QA', color: '#ff6ad5' });
+    assert.ok(createdTag.id, 'created tag should have id');
+
+    const removed = await client.delete(`/api/tags/${createdTag.id}`);
+    assert.equal(removed.id, createdTag.id, 'removed tag should match created tag');
+
+    const createdInvoice = await client.post('/api/invoices', {
+      vendor: 'Testeur Inc.',
+      amountTotal: 42.5,
+      invoiceDate: '2024-01-01',
+      source: 'upload',
+      paymentMethod: 'Visa',
+      previewUrl: '',
+    });
+    assert.equal(createdInvoice.vendor, 'Testeur Inc.');
+
+    const fetchedInvoice = await client.get(`/api/invoices/${createdInvoice.id}`);
+    assert.equal(fetchedInvoice.id, createdInvoice.id, 'created invoice should be retrievable');
+
+    const message = await client.post(`/api/invoices/${createdInvoice.id}/messages`, {
+      body: 'Bonjour! Peux-tu confirmer?',
+    });
+    assert.equal(message.body, 'Bonjour! Peux-tu confirmer?');
+
+    const tagged = await client.post(`/api/invoices/${createdInvoice.id}/tags`, {
+      tagId: tags[0].id,
+      appliedByUserId: 'user-tagger',
+    });
+    assert.ok(tagged.tags.some((entry) => entry.tagId === tags[0].id), 'tag should be applied');
+
+    console.log('Tests API réussis.');
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    server.kill('SIGTERM');
+    await new Promise((resolve) => server.on('exit', resolve));
+    await rm(tempDir, { recursive: true, force: true });
+  }
+})();
+
+async function waitForServer(port) {
+  const url = `http://localhost:${port}/api/tags`;
+  const maxAttempts = 40;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch (_) {
+      // retry
+    }
+    await delay(150);
+  }
+  throw new Error('Le serveur ne répond pas.');
+}
+
+function createClient(port) {
+  const base = `http://localhost:${port}`;
+  return {
+    get: (path) => fetchJSON(`${base}${path}`),
+    post: (path, body) =>
+      fetchJSON(`${base}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+    delete: (path) => fetchJSON(`${base}${path}`, { method: 'DELETE' }),
+  };
+}
+
+async function fetchJSON(url, options = {}) {
+  const response = await fetch(url, options);
+  const isJson = response.headers.get('content-type')?.includes('application/json');
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`;
+    if (isJson) {
+      try {
+        const payload = await response.json();
+        if (payload?.error) {
+          message = payload.error;
+        }
+      } catch (_) {
+        // ignore
+      }
+    }
+    throw new Error(message);
+  }
+  if (!isJson || response.status === 204) {
+    return null;
+  }
+  return response.json();
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- implement drag-and-drop tagging and a removal dropzone with keyboard support plus toast-based undo
- expand the toast system with action buttons, drop target styling, and tag instructions in the detail view
- document the interaction changes in the README so reviewers understand the updated flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c89e1795fc8321af97aacb1ffed7eb